### PR TITLE
MV-477: [MV-MIOpen] Benchmark & Port SoftmaxCrossEntropyWithLogits Contiguous

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -32,3 +32,4 @@ The MIOpen API library is structured as follows:
   * :doc:`GroupNorm <../doxygen/html/group__groupnorm>` (experimental)
   * :doc:`Cat <../doxygen/html/group__cat>` (experimental)
   * :doc:`Argmax<./argmax>` (experimental)
+  * :doc:`SoftmaxCrossEntropyWithLogits <../doxygen/html/group__softmaxcrossentropywithlogits>` (experimental)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(MIOpenDriver
     dm_reduce.cpp
     dm_rnn.cpp
     dm_softmax.cpp
+    dm_softmaxcrossentropywithlogits.cpp
     dm_sum.cpp
     dm_tensorop.cpp
     main.cpp

--- a/driver/dm_softmaxcrossentropywithlogits.cpp
+++ b/driver/dm_softmaxcrossentropywithlogits.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "registry_driver_maker.hpp"
+#include "softmaxcrossentropywithlogits_driver.hpp"
+
+static Driver* makeDriver(const std::string& base_arg)
+{
+    if(base_arg == "softmaxcrossentropywithlogits")
+        return new SoftmaxCrossEntropyWithLogitsDriver<float, float>();
+    if(base_arg == "softmaxcrossentropywithlogitsfp16")
+        return new SoftmaxCrossEntropyWithLogitsDriver<float16, float>();
+    if(base_arg == "softmaxcrossentropywithlogitsbfp16")
+        return new SoftmaxCrossEntropyWithLogitsDriver<bfloat16, float>();
+    return nullptr;
+}
+
+REGISTER_DRIVER_MAKER(makeDriver);

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -151,7 +151,8 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
            "pool[fp16], lrn[fp16], "
            "activ[fp16], softmax[fp16], bnorm[fp16], rnn[fp16], gemm[fp16], ctc, dropout[fp16], "
            "tensorop[fp16], reduce[fp16|fp64], layernorm[bfp16|fp16], sum[bfp16|fp16], "
-           "argmax[bfp16|fp16], groupnorm[bfp16|fp16], cat[bfp16|fp16]\n");
+           "argmax[bfp16|fp16], groupnorm[bfp16|fp16], cat[bfp16|fp16], "
+           "softmaxcrossentropywithlogits[bfp16|fp16]\n");
     exit(0); // NOLINT (concurrency-mt-unsafe)
 }
 
@@ -176,7 +177,9 @@ inline std::string ParseBaseArg(int argc, char* argv[])
        arg != "layernormfp16" && arg != "layernormbfp16" && arg != "sum" && arg != "sumfp16" &&
        arg != "sumbfp16" && arg != "argmax" && arg != "argmaxfp16" && arg != "argmaxbfp16" &&
        arg != "groupnorm" && arg != "groupnormfp16" && arg != "groupnormbfp16" && arg != "cat" &&
-       arg != "catfp16" && arg != "catbfp16" && arg != "--version")
+       arg != "catfp16" && arg != "catbfp16" && arg != "softmaxcrossentropywithlogits" &&
+       arg != "softmaxcrossentropywithlogitsfp16" && arg != "softmaxcrossentropywithlogitsbfp16" &&
+       arg != "--version")
     {
         printf("FAILED: Invalid Base Input Argument\n");
         Usage();

--- a/driver/mloSoftmaxCrossEntropyWithLogitsHost.hpp
+++ b/driver/mloSoftmaxCrossEntropyWithLogitsHost.hpp
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef MLO_SOFTMAXCROSSENTROPYWITHLOGITS_H_
+#define MLO_SOFTMAXCROSSENTROPYWITHLOGITS_H_
+
+#include <miopen/tensor.hpp>
+#include <miopen/tensor_view.hpp>
+
+template <typename Tgpu, typename Tcheck>
+int32_t mloSoftmaxCrossEntropyWithLogitsForward(const miopenTensorDescriptor_t inputDesc,
+                                                const miopenTensorDescriptor_t targetDesc,
+                                                const miopenTensorDescriptor_t outputDesc,
+                                                const miopenTensorDescriptor_t backpropDesc,
+                                                const Tgpu* input,
+                                                const Tgpu* target,
+                                                Tcheck* output,
+                                                Tcheck* backprop)
+{
+    auto I_tv = get_inner_expanded_tv_2d(miopen::deref(inputDesc));
+    auto T_tv = get_inner_expanded_tv_2d(miopen::deref(targetDesc));
+    auto O_tv = get_inner_expanded_tv_1d(miopen::deref(outputDesc));
+    auto B_tv = get_inner_expanded_tv_2d(miopen::deref(backpropDesc));
+
+    size_t num_batches = miopen::deref(inputDesc).GetLengths()[0];
+    size_t num_class   = miopen::deref(inputDesc).GetLengths()[1];
+
+    for(size_t gid = 0; gid < num_batches; ++gid)
+    {
+        float max_val = -std::numeric_limits<float>::infinity();
+
+        for(size_t i = 0; i < num_class; ++i)
+        {
+            size_t Iidx = TV2D_IDX(I_tv, gid, i);
+            float val   = static_cast<float>(input[Iidx]);
+            max_val     = std::max(max_val, val);
+        }
+
+        float sum = 0.0f;
+        for(size_t i = 0; i < num_class; ++i)
+        {
+            size_t Iidx = TV2D_IDX(I_tv, gid, i);
+            sum += std::exp(static_cast<float>(input[Iidx]) - max_val);
+        }
+
+        float log_sum = std::log(sum);
+        float loss    = 0.0f;
+        for(size_t i = 0; i < num_class; ++i)
+        {
+            size_t Iidx = TV2D_IDX(I_tv, gid, i);
+            size_t Tidx = TV2D_IDX(T_tv, gid, i);
+            float val   = static_cast<float>(input[Iidx]);
+            float label = static_cast<float>(target[Tidx]);
+            loss += label * (log_sum - val + max_val);
+        }
+
+        size_t Oidx  = TV1D_IDX(O_tv, gid);
+        output[Oidx] = static_cast<Tcheck>(loss);
+
+        for(size_t i = 0; i < num_class; ++i)
+        {
+            size_t Iidx        = TV2D_IDX(I_tv, gid, i);
+            size_t Tidx        = TV2D_IDX(T_tv, gid, i);
+            size_t Bidx        = TV2D_IDX(B_tv, gid, i);
+            float val          = static_cast<float>(input[Iidx]);
+            float label        = static_cast<float>(target[Tidx]);
+            float backprop_val = std::exp(val - max_val) / sum - label;
+            backprop[Bidx]     = static_cast<Tcheck>(backprop_val);
+        }
+    }
+    return 0;
+}
+
+template <typename Tgpu, typename Tcheck>
+int32_t mloSoftmaxCrossEntropyWithLogitsBackward(const miopenTensorDescriptor_t outputGradDesc,
+                                                 const miopenTensorDescriptor_t backpropDesc,
+                                                 const miopenTensorDescriptor_t inputDesc,
+                                                 const miopenTensorDescriptor_t inputGradDesc,
+                                                 const miopenTensorDescriptor_t targetGradDesc,
+                                                 const Tgpu* output_grad,
+                                                 const Tgpu* backprop,
+                                                 const Tgpu* input,
+                                                 Tcheck* input_grad,
+                                                 Tcheck* target_grad,
+                                                 bool input_grad_out,
+                                                 bool target_grad_out)
+{
+    auto dO_tv = get_inner_expanded_tv_1d(miopen::deref(outputGradDesc));
+    auto B_tv  = get_inner_expanded_tv_2d(miopen::deref(backpropDesc));
+    auto I_tv  = get_inner_expanded_tv_2d(miopen::deref(inputDesc));
+    auto dI_tv = get_inner_expanded_tv_2d(miopen::deref(inputGradDesc));
+    auto dT_tv = get_inner_expanded_tv_2d(miopen::deref(targetGradDesc));
+
+    size_t num_batches = miopen::deref(inputDesc).GetLengths()[0];
+    size_t num_class   = miopen::deref(inputDesc).GetLengths()[1];
+
+    for(size_t gid = 0; gid < num_batches; ++gid)
+    {
+        size_t dOidx          = TV1D_IDX(dO_tv, gid);
+        float output_grad_val = static_cast<float>(output_grad[dOidx]);
+
+        if(input_grad_out)
+        {
+            for(size_t i = 0; i < num_class; ++i)
+            {
+                size_t Bidx        = TV2D_IDX(B_tv, gid, i);
+                size_t dIidx       = TV2D_IDX(dI_tv, gid, i);
+                float backprop_val = static_cast<float>(backprop[Bidx]);
+                input_grad[dIidx]  = static_cast<Tcheck>(output_grad_val * backprop_val);
+            }
+        }
+
+        if(target_grad_out)
+        {
+            float max_val = -std::numeric_limits<float>::infinity();
+            for(size_t i = 0; i < num_class; ++i)
+            {
+                size_t Iidx = TV2D_IDX(I_tv, gid, i);
+                float val   = static_cast<float>(input[Iidx]);
+                max_val     = std::max(max_val, val);
+            }
+
+            float sum = 0.0f;
+            for(size_t i = 0; i < num_class; ++i)
+            {
+                size_t Iidx = TV2D_IDX(I_tv, gid, i);
+                float val   = static_cast<float>(input[Iidx]);
+                sum += std::exp(val - max_val);
+            }
+
+            float log_val = std::log(sum);
+            for(size_t i = 0; i < num_class; ++i)
+            {
+                size_t Iidx     = TV2D_IDX(I_tv, gid, i);
+                float logit_val = static_cast<float>(input[Iidx]);
+                size_t Tidx     = TV2D_IDX(dT_tv, gid, i);
+                target_grad[Tidx] =
+                    static_cast<Tcheck>((max_val + log_val - logit_val) * output_grad_val);
+            }
+        }
+    }
+    return 0;
+}
+
+#endif // MLO_SOFTMAXCROSSENTROPYWITHLOGITS_H_

--- a/driver/mloSoftmaxCrossEntropyWithLogitsHost.hpp
+++ b/driver/mloSoftmaxCrossEntropyWithLogitsHost.hpp
@@ -110,8 +110,6 @@ int32_t mloSoftmaxCrossEntropyWithLogitsBackward(const miopenTensorDescriptor_t 
     auto dO_tv = get_inner_expanded_tv_1d(miopen::deref(outputGradDesc));
     auto B_tv  = get_inner_expanded_tv_2d(miopen::deref(backpropDesc));
     auto I_tv  = get_inner_expanded_tv_2d(miopen::deref(inputDesc));
-    auto dI_tv = get_inner_expanded_tv_2d(miopen::deref(inputGradDesc));
-    auto dT_tv = get_inner_expanded_tv_2d(miopen::deref(targetGradDesc));
 
     size_t num_batches = miopen::deref(inputDesc).GetLengths()[0];
     size_t num_class   = miopen::deref(inputDesc).GetLengths()[1];
@@ -123,6 +121,7 @@ int32_t mloSoftmaxCrossEntropyWithLogitsBackward(const miopenTensorDescriptor_t 
 
         if(input_grad_out)
         {
+            auto dI_tv = get_inner_expanded_tv_2d(miopen::deref(inputGradDesc));
             for(size_t i = 0; i < num_class; ++i)
             {
                 size_t Bidx        = TV2D_IDX(B_tv, gid, i);
@@ -134,6 +133,7 @@ int32_t mloSoftmaxCrossEntropyWithLogitsBackward(const miopenTensorDescriptor_t 
 
         if(target_grad_out)
         {
+            auto dT_tv    = get_inner_expanded_tv_2d(miopen::deref(targetGradDesc));
             float max_val = -std::numeric_limits<float>::infinity();
             for(size_t i = 0; i < num_class; ++i)
             {

--- a/driver/softmaxcrossentropywithlogits_driver.hpp
+++ b/driver/softmaxcrossentropywithlogits_driver.hpp
@@ -1,0 +1,531 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef GUARD_MIOPEN_SOFTMAXCROSSENTROPYWITHLOGITS_DRIVER_HPP
+#define GUARD_MIOPEN_SOFTMAXCROSSENTROPYWITHLOGITS_DRIVER_HPP
+
+#include "InputFlags.hpp"
+#include "driver.hpp"
+#include "mloSoftmaxCrossEntropyWithLogitsHost.hpp"
+#include "random.hpp"
+#include "tensor_driver.hpp"
+#include "timer.hpp"
+#include "util_driver.hpp"
+
+#include <../test/tensor_holder.hpp>
+#include <../test/verify.hpp>
+
+#include <miopen/env.hpp>
+#include <miopen/handle.hpp>
+#include <miopen/miopen.h>
+#include <miopen/tensor.hpp>
+#include <vector>
+
+inline std::vector<int> GetStrides(std::vector<int> lengths, int contiguous)
+{
+    if(contiguous != 0 && contiguous != 1)
+        std::cerr << "Error Tensor Contiguous should be 0 or 1" << std::endl;
+    if(contiguous == 0)
+        std::swap(lengths.front(), lengths.back());
+    std::vector<int> strides(lengths.size());
+    strides.back() = 1;
+    for(int i = lengths.size() - 2; i >= 0; --i)
+        strides[i] = strides[i + 1] * lengths[i + 1];
+    if(contiguous == 0)
+        std::swap(strides.front(), strides.back());
+    return strides;
+}
+
+template <typename Tgpu, typename Tref>
+class SoftmaxCrossEntropyWithLogitsDriver : public Driver
+{
+public:
+    SoftmaxCrossEntropyWithLogitsDriver() : Driver()
+    {
+        miopenCreateTensorDescriptor(&inputDesc);
+        miopenCreateTensorDescriptor(&targetDesc);
+        miopenCreateTensorDescriptor(&outputDesc);
+        miopenCreateTensorDescriptor(&backpropDesc);
+        miopenCreateTensorDescriptor(&outputGradDesc);
+        miopenCreateTensorDescriptor(&inputGradDesc);
+        miopenCreateTensorDescriptor(&targetGradDesc);
+
+        data_type = miopen_type<Tgpu>{};
+    }
+
+    int AddCmdLineArgs() override;
+    int ParseCmdLineArgs(int argc, char* argv[]) override;
+    InputFlags& GetInputFlags() override { return inflags; }
+
+    std::vector<int> GetInputTensorDimsFromCmd();
+    int GetandSetData() override;
+
+    int AllocateBuffersAndCopy() override;
+
+    int RunForwardGPU() override;
+    int RunForwardCPU();
+
+    int RunBackwardGPU() override;
+    int RunBackwardCPU();
+
+    int VerifyBackward() override;
+    int VerifyForward() override;
+    ~SoftmaxCrossEntropyWithLogitsDriver() override
+    {
+        miopenDestroyTensorDescriptor(inputDesc);
+        miopenDestroyTensorDescriptor(targetDesc);
+        miopenDestroyTensorDescriptor(outputDesc);
+        miopenDestroyTensorDescriptor(backpropDesc);
+        miopenDestroyTensorDescriptor(outputGradDesc);
+        miopenDestroyTensorDescriptor(inputGradDesc);
+        miopenDestroyTensorDescriptor(targetGradDesc);
+    }
+
+private:
+    InputFlags inflags;
+
+    int forw;
+
+    miopenTensorDescriptor_t inputDesc;
+    miopenTensorDescriptor_t targetDesc;
+    miopenTensorDescriptor_t outputDesc;
+    miopenTensorDescriptor_t backpropDesc;
+    miopenTensorDescriptor_t outputGradDesc;
+    miopenTensorDescriptor_t inputGradDesc;
+    miopenTensorDescriptor_t targetGradDesc;
+
+    std::unique_ptr<GPUMem> in_dev;
+    std::unique_ptr<GPUMem> target_dev;
+    std::unique_ptr<GPUMem> out_dev;
+    std::unique_ptr<GPUMem> backprop_dev;
+
+    std::unique_ptr<GPUMem> workspace_dev_fwd;
+    std::unique_ptr<GPUMem> workspace_dev_bwd;
+    std::unique_ptr<GPUMem> out_grad_dev;
+    std::unique_ptr<GPUMem> in_grad_dev;
+    std::unique_ptr<GPUMem> target_grad_dev;
+
+    std::vector<Tgpu> in;
+    std::vector<Tgpu> target;
+    std::vector<Tgpu> out;
+    std::vector<Tgpu> backprop;
+    std::vector<Tref> out_host;
+    std::vector<Tref> backprop_host;
+
+    std::vector<Tgpu> out_grad;
+    std::vector<Tgpu> in_grad;
+    std::vector<Tgpu> target_grad;
+    std::vector<Tref> in_grad_host;
+    std::vector<Tref> target_grad_host;
+
+    size_t ws_sizeInBytes_fwd = 0;
+    size_t ws_sizeInBytes_bwd = 0;
+
+    std::vector<int> input_sizes;
+};
+
+template <typename Tgpu, typename Tref>
+int SoftmaxCrossEntropyWithLogitsDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
+{
+    inflags.Parse(argc, argv);
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        miopenEnableProfiling(GetHandle(), true);
+    }
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+std::vector<int> SoftmaxCrossEntropyWithLogitsDriver<Tgpu, Tref>::GetInputTensorDimsFromCmd()
+{
+    std::string lengthsStr = inflags.GetValueStr("input_dims");
+
+    std::vector<int> lengths;
+    std::size_t pos = 0;
+    std::size_t new_pos;
+
+    new_pos = lengthsStr.find(',', pos);
+    while(new_pos != std::string::npos)
+    {
+        std::string sliceStr = lengthsStr.substr(pos, new_pos - pos);
+
+        int len = std::stoi(sliceStr);
+
+        lengths.push_back(len);
+
+        pos     = new_pos + 1;
+        new_pos = lengthsStr.find(',', pos);
+    };
+
+    std::string sliceStr = lengthsStr.substr(pos);
+    int len              = std::stoi(sliceStr);
+
+    lengths.push_back(len);
+
+    return (lengths);
+}
+
+template <typename Tgpu, typename Tref>
+int SoftmaxCrossEntropyWithLogitsDriver<Tgpu, Tref>::GetandSetData()
+{
+    input_sizes = GetInputTensorDimsFromCmd();
+
+    std::vector<int> in_len       = input_sizes;
+    std::vector<int> target_len   = input_sizes;
+    std::vector<int> out_len      = std::vector<int>{in_len[0]};
+    std::vector<int> backprop_len = input_sizes;
+
+    auto in_strides       = GetStrides(in_len, inflags.GetValueInt("contiguous"));
+    auto tar_strides      = GetStrides(target_len, 1);
+    auto output_strides   = GetStrides(out_len, 1);
+    auto backprop_strides = GetStrides(backprop_len, 1);
+
+    SetTensorNd(inputDesc, in_len, in_strides, data_type);
+    SetTensorNd(targetDesc, target_len, tar_strides, data_type);
+    SetTensorNd(outputDesc, out_len, output_strides, data_type);
+    SetTensorNd(backpropDesc, backprop_len, backprop_strides, data_type);
+
+    SetTensorNd(outputGradDesc, out_len, output_strides, data_type);
+    SetTensorNd(inputGradDesc, in_len, in_strides, data_type);
+    SetTensorNd(targetGradDesc, target_len, tar_strides, data_type);
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SoftmaxCrossEntropyWithLogitsDriver<Tgpu, Tref>::AddCmdLineArgs()
+{
+    inflags.AddInputFlag(
+        "forw", 'F', "1", "Run only Forward SoftmaxCrossEntropyWithLogits (Default=1)", "int");
+    inflags.AddInputFlag("input_dims",
+                         'D',
+                         "16,21",
+                         "The dimensional lengths of the input tensor: N,C. Example: 16,64.",
+                         "string");
+    inflags.AddInputFlag("contiguous",
+                         'c',
+                         "1",
+                         "Is input tensor contiguous? (Default=1 for contiguous tensor)",
+                         "int");
+
+    inflags.AddInputFlag("iter", 'i', "10", "Number of Iterations (Default=10)", "int");
+    inflags.AddInputFlag("verify", 'V', "1", "Verify (Default=1)", "int");
+    inflags.AddInputFlag("time", 't', "1", "Time (Default=1)", "int");
+    inflags.AddInputFlag(
+        "wall", 'w', "0", "Wall-clock Time, Requires time == 1 (Default=0)", "int");
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SoftmaxCrossEntropyWithLogitsDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
+{
+    size_t in_sz       = GetTensorSize(inputDesc);
+    size_t target_sz   = GetTensorSize(targetDesc);
+    size_t out_sz      = GetTensorSize(outputDesc);
+    size_t backprop_sz = GetTensorSize(backpropDesc);
+
+    uint32_t ctx = 0;
+
+    in_dev       = std::unique_ptr<GPUMem>(new GPUMem(ctx, in_sz, sizeof(Tgpu)));
+    target_dev   = std::unique_ptr<GPUMem>(new GPUMem(ctx, target_sz, sizeof(Tgpu)));
+    out_dev      = std::unique_ptr<GPUMem>(new GPUMem(ctx, out_sz, sizeof(Tgpu)));
+    backprop_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, backprop_sz, sizeof(Tgpu)));
+
+    workspace_dev_fwd =
+        std::unique_ptr<GPUMem>(new GPUMem(ctx, ws_sizeInBytes_fwd, sizeof(std::byte)));
+
+    workspace_dev_bwd =
+        std::unique_ptr<GPUMem>(new GPUMem(ctx, ws_sizeInBytes_bwd, sizeof(std::byte)));
+
+    out_grad_dev    = std::unique_ptr<GPUMem>(new GPUMem(ctx, out_sz, sizeof(Tgpu)));
+    in_grad_dev     = std::unique_ptr<GPUMem>(new GPUMem(ctx, in_sz, sizeof(Tgpu)));
+    target_grad_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, target_sz, sizeof(Tgpu)));
+
+    in            = std::vector<Tgpu>(in_sz, static_cast<Tgpu>(0));
+    target        = std::vector<Tgpu>(target_sz, static_cast<Tgpu>(0));
+    out           = std::vector<Tgpu>(out_sz, static_cast<Tgpu>(0));
+    backprop      = std::vector<Tgpu>(backprop_sz, static_cast<Tgpu>(0));
+    out_host      = std::vector<Tref>(out_sz, static_cast<Tref>(0));
+    backprop_host = std::vector<Tref>(backprop_sz, static_cast<Tref>(0));
+
+    out_grad         = std::vector<Tgpu>(out_sz, static_cast<Tgpu>(0));
+    in_grad          = std::vector<Tgpu>(in_sz, static_cast<Tgpu>(0));
+    target_grad      = std::vector<Tgpu>(in_sz, static_cast<Tgpu>(0));
+    in_grad_host     = std::vector<Tref>(in_sz, static_cast<Tref>(0));
+    target_grad_host = std::vector<Tref>(in_sz, static_cast<Tref>(0));
+
+    int status;
+
+    for(int i = 0; i < in_sz; i++)
+    {
+        in[i] = prng::gen_A_to_B<Tgpu>(static_cast<Tgpu>(-5.0f), static_cast<Tgpu>(1.0f));
+    }
+    status = in_dev->ToGPU(q, in.data());
+
+    size_t num_classes = out_sz;
+    size_t num_batches = in_sz / num_classes;
+    for(int i = 0; i < num_batches; i++)
+    {
+        for(int j = 0; j < num_classes; j++)
+        {
+            if(j == i % num_classes)
+                target[i * num_classes + j] = (static_cast<Tgpu>(1.0f));
+            else
+                target[i * num_classes + j] = (static_cast<Tgpu>(0.0f));
+        }
+    }
+
+    status |= target_dev->ToGPU(q, target.data());
+
+    status |= out_dev->ToGPU(q, out.data());
+
+    status |= backprop_dev->ToGPU(q, backprop.data());
+
+    status |= in_grad_dev->ToGPU(q, in_grad.data());
+    status |= target_grad_dev->ToGPU(q, target_grad.data());
+
+    for(int i = 0; i < out_sz; i++)
+    {
+        out_grad[i] = prng::gen_A_to_B<Tgpu>(static_cast<Tgpu>(-10.0), static_cast<Tgpu>(10.0));
+    }
+    status |= out_grad_dev->ToGPU(q, out_grad.data());
+
+    if(status != 0)
+        std::cout << "Error copying data to GPU\n" << std::endl;
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SoftmaxCrossEntropyWithLogitsDriver<Tgpu, Tref>::RunForwardGPU()
+{
+    float kernel_total_time = 0.0;
+    float kernel_first_time = 0.0;
+
+    Timer t;
+    START_TIME
+
+    for(int i = 0; i < inflags.GetValueInt("iter"); i++)
+    {
+        miopenSoftmaxCrossEntropyWithLogitsForward(GetHandle(),
+                                                   workspace_dev_fwd->GetMem(),
+                                                   ws_sizeInBytes_fwd,
+                                                   inputDesc,
+                                                   in_dev->GetMem(),
+                                                   targetDesc,
+                                                   target_dev->GetMem(),
+                                                   outputDesc,
+                                                   out_dev->GetMem(),
+                                                   backpropDesc,
+                                                   backprop_dev->GetMem());
+
+        float time = 0.0;
+        miopenGetKernelTime(GetHandle(), &time);
+        kernel_total_time += time;
+        if(i == 0)
+            kernel_first_time = time;
+    }
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        STOP_TIME
+        int iter = inflags.GetValueInt("iter");
+        if(WALL_CLOCK)
+            printf("Wall-clock Time Forward SoftmaxCrossEntropyWithLogits Elapsed: %f ms\n",
+                   t.gettime_ms() / iter);
+
+        float kernel_average_time =
+            iter > 1 ? (kernel_total_time - kernel_first_time) / (iter - 1) : kernel_first_time;
+        printf("GPU Kernel Time Forward SoftmaxCrossEntropyWithLogits Elapsed: %f ms\n",
+               kernel_average_time);
+    }
+
+    out_dev->FromGPU(GetStream(), out.data());
+    backprop_dev->FromGPU(GetStream(), backprop.data());
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SoftmaxCrossEntropyWithLogitsDriver<Tgpu, Tref>::RunForwardCPU()
+{
+    mloSoftmaxCrossEntropyWithLogitsForward<Tgpu, Tref>(inputDesc,
+                                                        targetDesc,
+                                                        outputDesc,
+                                                        backpropDesc,
+                                                        in.data(),
+                                                        target.data(),
+                                                        out_host.data(),
+                                                        backprop_host.data());
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SoftmaxCrossEntropyWithLogitsDriver<Tgpu, Tref>::RunBackwardGPU()
+{
+    float kernel_total_time = 0.0;
+    float kernel_first_time = 0.0;
+
+    Timer t;
+    START_TIME
+
+    for(int i = 0; i < inflags.GetValueInt("iter"); i++)
+    {
+        miopenSoftmaxCrossEntropyWithLogitsBackward(GetHandle(),
+                                                    workspace_dev_bwd->GetMem(),
+                                                    ws_sizeInBytes_bwd,
+                                                    outputGradDesc,
+                                                    out_grad_dev->GetMem(),
+                                                    backpropDesc,
+                                                    backprop_dev->GetMem(),
+                                                    inputDesc,
+                                                    in_dev->GetMem(),
+                                                    inputGradDesc,
+                                                    in_grad_dev->GetMem(),
+                                                    targetGradDesc,
+                                                    target_grad_dev->GetMem());
+
+        float time = 0.0;
+        miopenGetKernelTime(GetHandle(), &time);
+        kernel_total_time += time;
+        if(i == 0)
+            kernel_first_time = time;
+    }
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        STOP_TIME
+        int iter = inflags.GetValueInt("iter");
+        if(WALL_CLOCK)
+            printf("Wall-clock Time Backward SoftmaxCrossEntropyWithLogits Elapsed: %f ms\n",
+                   t.gettime_ms() / iter);
+
+        float kernel_average_time =
+            iter > 1 ? (kernel_total_time - kernel_first_time) / (iter - 1) : kernel_first_time;
+        printf("GPU Kernel Time Backward SoftmaxCrossEntropyWithLogits Elapsed: %f ms\n",
+               kernel_average_time);
+    }
+
+    in_grad_dev->FromGPU(GetStream(), in_grad.data());
+    target_grad_dev->FromGPU(GetStream(), target_grad.data());
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SoftmaxCrossEntropyWithLogitsDriver<Tgpu, Tref>::RunBackwardCPU()
+{
+    mloSoftmaxCrossEntropyWithLogitsBackward<Tgpu, Tref>(outputGradDesc,
+                                                         backpropDesc,
+                                                         inputDesc,
+                                                         inputGradDesc,
+                                                         targetGradDesc,
+                                                         out_grad.data(),
+                                                         backprop.data(),
+                                                         in.data(),
+                                                         in_grad_host.data(),
+                                                         target_grad_host.data(),
+                                                         true,
+                                                         true);
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SoftmaxCrossEntropyWithLogitsDriver<Tgpu, Tref>::VerifyForward()
+{
+    RunForwardCPU();
+    auto tolerance = std::numeric_limits<Tgpu>::epsilon() * 10;
+
+    auto error = miopen::rms_range(out_host, out);
+    if(!std::isfinite(error) || error > tolerance)
+    {
+        std::cout << "Output Forward SoftmaxCrossEntropyWithLogits FAILED: " << error << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        printf("Output Forward SoftmaxCrossEntropyWithLogits Verifies on CPU and GPU (err=%f)\n",
+               error);
+    }
+
+    auto backprop_error = miopen::rms_range(backprop_host, backprop);
+    if(!std::isfinite(backprop_error) || backprop_error > tolerance)
+    {
+        std::cout << "Backprop Forward SoftmaxCrossEntropyWithLogits FAILED: " << backprop_error
+                  << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        printf("Backprop Forward SoftmaxCrossEntropyWithLogits Verifies on CPU and GPU (err=%f)\n",
+               backprop_error);
+    }
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SoftmaxCrossEntropyWithLogitsDriver<Tgpu, Tref>::VerifyBackward()
+{
+    RunBackwardCPU();
+    auto tolerance = std::numeric_limits<Tgpu>::epsilon() * 10;
+    auto error1    = miopen::rms_range(in_grad_host, in_grad);
+
+    if(!std::isfinite(error1) || error1 > tolerance)
+    {
+        std::cout << "Backward SoftmaxCrossEntropyWithLogits in Input Grad FAILED: " << error1
+                  << " while tolerance: " << tolerance << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        printf("Backward SoftmaxCrossEntropyWithLogits Verifies in Input Grad on CPU and GPU "
+               "(err=%f)\n",
+               error1);
+    }
+
+    auto error2 = miopen::rms_range(target_grad_host, target_grad);
+
+    if(!std::isfinite(error2) || error2 > tolerance)
+    {
+        std::cout << "Backward SoftmaxCrossEntropyWithLogits in Target Grad FAILED: " << error2
+                  << " while tolerance: " << tolerance << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        printf("Backward SoftmaxCrossEntropyWithLogits Verifies in Target Grad on CPU and GPU "
+               "(err=%f)\n",
+               error2);
+    }
+
+    return miopenStatusSuccess;
+}
+
+#endif // GUARD_MIOPEN_SOFTMAXCROSSENTROPYWITHLOGITS_DRIVER_HPP

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -513,7 +513,7 @@ typedef enum
     miopenActivationABS      = 5, /*!< Absolute value \f$abs(x)\f$ */
     miopenActivationPOWER = 6, /*!< Scaled and shifted power \f$(\alpha + \beta * x)^{gamma}\f$ */
     miopenActivationCLIPPEDRELU =
-        7,                     /*!< Clipped Rectified Linear Unit \f$ min(\alpha, max(0,x)) \f$ */
+        7, /*!< Clipped Rectified Linear Unit \f$ min(\alpha, max(0,x)) \f$ */
     miopenActivationLEAKYRELU =
         8, /*!< Leaky Rectified Linear Unit \f$ \alpha * x | x <= 0; x | x > 0 \f$ */
     miopenActivationELU =

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -6591,30 +6591,9 @@ MIOPEN_EXPORT miopenStatus_t miopenBackendInitialize(miopenBackendDescriptor_t d
  *  @{
  */
 
-/*! @brief Helper function to query the minimum workspace size required by the
- * SoftmaxCrossEntropyWithLogits Forward call
- *
- * @param handle                   MIOpen Handle (input)
- * @param inputDesc                Tensor descriptor for input tensor (input)
- * @param targetDesc               Tensor descriptor for target tensor (input)
- * @param outputDesc               Tensor descriptor for output tensor (input)
- * @param backpropDesc             Tensor descriptor for backprop tensor (input)
- * @param sizeInBytes              Pointer to data to return the minimum workspace size (output)
- * @return                         miopenStatus_t
- */
-MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(
-    miopenHandle_t handle,
-    const miopenTensorDescriptor_t inputDesc,
-    const miopenTensorDescriptor_t targetDesc,
-    const miopenTensorDescriptor_t outputDesc,
-    const miopenTensorDescriptor_t backpropDesc,
-    size_t* sizeInBytes);
-
 /*! @brief Execute a softmaxcrossentropywithlogits forward layer
  *
  * @param handle                MIOpen handle (input)
- * @param workspace             Pointer to workspace (input)
- * @param workspaceSizeInBytes  Size of workspace buffer (input)
  * @param inputDesc             Tensor descriptor for input  tensor (input)
  * @param input                 Data tensor input  (input)
  * @param targetDesc            Tensor descriptor for target tensor (input)
@@ -6627,8 +6606,6 @@ MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsForwardWorksp
  */
 MIOPEN_EXPORT miopenStatus_t
 miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
-                                           void* workspace,
-                                           size_t workspaceSizeInBytes,
                                            const miopenTensorDescriptor_t inputDesc,
                                            const void* input,
                                            const miopenTensorDescriptor_t targetDesc,
@@ -6638,32 +6615,9 @@ miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
                                            const miopenTensorDescriptor_t backpropDesc,
                                            void* backprop);
 
-/*! @brief Helper function to query the minimum workspace size required by the
- * SoftmaxCrossEntropyWithLogits Backward call
- *
- * @param handle                   MIOpen Handle (input)
- * @param outputGradDesc           Tensor descriptor for output grad tensor (input)
- * @param backpropDesc             Tensor descriptor for backprop tensor (input)
- * @param inputDesc                Tensor descriptor for input tensor (input)
- * @param inputGradDesc            Tensor descriptor for input grad tensor (input)
- * @param targetGradDesc           Tensor descriptor for target grad tensor (input)
- * @param sizeInBytes              Pointer to data to return the minimum workspace size (output)
- * @return                         miopenStatus_t
- */
-MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(
-    miopenHandle_t handle,
-    const miopenTensorDescriptor_t outputGradDesc,
-    const miopenTensorDescriptor_t backpropDesc,
-    const miopenTensorDescriptor_t inputDesc,
-    const miopenTensorDescriptor_t inputGradDesc,
-    const miopenTensorDescriptor_t targetGradDesc,
-    size_t* sizeInBytes);
-
 /*! @brief Execute a softmaxcrossentropywithlogits backward layer
  *
  * @param handle                   MIOpen handle (input)
- * @param workspace                Pointer to workspace (input)
- * @param workspaceSizeInBytes     Size of workspace buffer (input)
  * @param outputGradDesc           Tensor descriptor for output grad tensor (input)
  * @param output_grad              Data tensor output grad (input)
  * @param backpropDesc             Tensor descriptor for backprop tensor (input)
@@ -6678,8 +6632,6 @@ MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsBackwardWorks
  */
 MIOPEN_EXPORT miopenStatus_t
 miopenSoftmaxCrossEntropyWithLogitsBackward(miopenHandle_t handle,
-                                            void* workspace,
-                                            size_t workspaceSizeInBytes,
                                             const miopenTensorDescriptor_t outputGradDesc,
                                             const void* output_grad,
                                             const miopenTensorDescriptor_t backpropDesc,

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -6585,17 +6585,6 @@ MIOPEN_EXPORT miopenStatus_t miopenBackendInitialize(miopenBackendDescriptor_t d
 
 #ifdef MIOPEN_BETA_API
 
-/*! @ingroup softmaxcrossentropywithlogits
- * @enum miopenLossContiguousMode_t
- * Contiguous modes for SoftmaxCrossEntropyWithLogits
- */
-
-typedef enum
-{
-    MIOPEN_LOSS_NON_CONTIGUOUS = 0,
-    MIOPEN_LOSS_CONTIGUOUS     = 1,
-} miopenLossContiguousMode_t;
-
 // SoftmaxCrossEntropyWithLogits APIs
 /** @addtogroup softmaxcrossentropywithlogits
  *
@@ -6611,7 +6600,6 @@ typedef enum
  * @param outputDesc               Tensor descriptor for output tensor (input)
  * @param backpropDesc             Tensor descriptor for backprop tensor (input)
  * @param sizeInBytes              Pointer to data to return the minimum workspace size (output)
- * @param is_contiguous            Contiguous or non-contiguous (input)
  * @return                         miopenStatus_t
  */
 MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(
@@ -6620,8 +6608,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsForwardWorksp
     const miopenTensorDescriptor_t targetDesc,
     const miopenTensorDescriptor_t outputDesc,
     const miopenTensorDescriptor_t backpropDesc,
-    size_t* sizeInBytes,
-    const miopenLossContiguousMode_t is_contiguous);
+    size_t* sizeInBytes);
 
 /*! @brief Execute a softmaxcrossentropywithlogits forward layer
  *
@@ -6636,7 +6623,6 @@ MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsForwardWorksp
  * @param output                Data tensor output (output)
  * @param backpropDesc          Tensor descriptor for backprop tensor (input)
  * @param backprop              Data tensor backprop (output)
- * @param is_contiguous         Contiguous or non-contiguous (input)
  * @return                      miopenStatus_t
  */
 MIOPEN_EXPORT miopenStatus_t
@@ -6650,8 +6636,7 @@ miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
                                            const miopenTensorDescriptor_t outputDesc,
                                            void* output,
                                            const miopenTensorDescriptor_t backpropDesc,
-                                           void* backprop,
-                                           const miopenLossContiguousMode_t is_contiguous);
+                                           void* backprop);
 
 /*! @brief Helper function to query the minimum workspace size required by the
  * SoftmaxCrossEntropyWithLogits Backward call
@@ -6663,7 +6648,6 @@ miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
  * @param inputGradDesc            Tensor descriptor for input grad tensor (input)
  * @param targetGradDesc           Tensor descriptor for target grad tensor (input)
  * @param sizeInBytes              Pointer to data to return the minimum workspace size (output)
- * @param is_contiguous            Contiguous or non-contiguous (input)
  * @return                         miopenStatus_t
  */
 MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(
@@ -6673,8 +6657,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsBackwardWorks
     const miopenTensorDescriptor_t inputDesc,
     const miopenTensorDescriptor_t inputGradDesc,
     const miopenTensorDescriptor_t targetGradDesc,
-    size_t* sizeInBytes,
-    const miopenLossContiguousMode_t is_contiguous);
+    size_t* sizeInBytes);
 
 /*! @brief Execute a softmaxcrossentropywithlogits backward layer
  *
@@ -6691,7 +6674,6 @@ MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsBackwardWorks
  * @param input_grad               Data tensor input grad (output)
  * @param targetGradDesc           Tensor descriptor for target grad tensor (input)
  * @param target_grad              Data tensor target grad (output)
- * @param is_contiguous            Contiguous or non-contiguous (input)
  * @return                         miopenStatus_t
  */
 MIOPEN_EXPORT miopenStatus_t
@@ -6707,8 +6689,7 @@ miopenSoftmaxCrossEntropyWithLogitsBackward(miopenHandle_t handle,
                                             const miopenTensorDescriptor_t inputGradDesc,
                                             void* input_grad,
                                             const miopenTensorDescriptor_t targetGradDesc,
-                                            void* target_grad,
-                                            const miopenLossContiguousMode_t is_contiguous);
+                                            void* target_grad);
 
 /** @} */
 // CLOSEOUT SoftmaxCrossEntropyWithLogits DOXYGEN GROUP

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -68,6 +68,7 @@
  * @defgroup argmax
  * @defgroup groupnorm
  * @defgroup cat
+ * @defgroup softmaxcrossentropywithlogits
  *
  */
 
@@ -512,7 +513,7 @@ typedef enum
     miopenActivationABS      = 5, /*!< Absolute value \f$abs(x)\f$ */
     miopenActivationPOWER = 6, /*!< Scaled and shifted power \f$(\alpha + \beta * x)^{gamma}\f$ */
     miopenActivationCLIPPEDRELU =
-        7, /*!< Clipped Rectified Linear Unit \f$ min(\alpha, max(0,x)) \f$ */
+        7,                     /*!< Clipped Rectified Linear Unit \f$ min(\alpha, max(0,x)) \f$ */
     miopenActivationLEAKYRELU =
         8, /*!< Leaky Rectified Linear Unit \f$ \alpha * x | x <= 0; x | x > 0 \f$ */
     miopenActivationELU =
@@ -6580,6 +6581,137 @@ MIOPEN_EXPORT miopenStatus_t miopenBackendInitialize(miopenBackendDescriptor_t d
 
 /** @} */
 // CLOSEOUT BackendAPI DOXYGEN GROUP
+#endif // MIOPEN_BETA_API
+
+#ifdef MIOPEN_BETA_API
+
+/*! @ingroup softmaxcrossentropywithlogits
+ * @enum miopenLossContiguousMode_t
+ * Contiguous modes for SoftmaxCrossEntropyWithLogits
+ */
+
+typedef enum
+{
+    MIOPEN_LOSS_NON_CONTIGUOUS = 0,
+    MIOPEN_LOSS_CONTIGUOUS     = 1,
+} miopenLossContiguousMode_t;
+
+// SoftmaxCrossEntropyWithLogits APIs
+/** @addtogroup softmaxcrossentropywithlogits
+ *
+ *  @{
+ */
+
+/*! @brief Helper function to query the minimum workspace size required by the
+ * SoftmaxCrossEntropyWithLogits Forward call
+ *
+ * @param handle                   MIOpen Handle (input)
+ * @param inputDesc                Tensor descriptor for input tensor (input)
+ * @param targetDesc               Tensor descriptor for target tensor (input)
+ * @param outputDesc               Tensor descriptor for output tensor (input)
+ * @param backpropDesc             Tensor descriptor for backprop tensor (input)
+ * @param sizeInBytes              Pointer to data to return the minimum workspace size (output)
+ * @param is_contiguous            Contiguous or non-contiguous (input)
+ * @return                         miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(
+    miopenHandle_t handle,
+    const miopenTensorDescriptor_t inputDesc,
+    const miopenTensorDescriptor_t targetDesc,
+    const miopenTensorDescriptor_t outputDesc,
+    const miopenTensorDescriptor_t backpropDesc,
+    size_t* sizeInBytes,
+    const miopenLossContiguousMode_t is_contiguous);
+
+/*! @brief Execute a softmaxcrossentropywithlogits forward layer
+ *
+ * @param handle                MIOpen handle (input)
+ * @param workspace             Pointer to workspace (input)
+ * @param workspaceSizeInBytes  Size of workspace buffer (input)
+ * @param inputDesc             Tensor descriptor for input  tensor (input)
+ * @param input                 Data tensor input  (input)
+ * @param targetDesc            Tensor descriptor for target tensor (input)
+ * @param target                Data tensor target (input)
+ * @param outputDesc            Tensor descriptor for output tensor (input)
+ * @param output                Data tensor output (output)
+ * @param backpropDesc          Tensor descriptor for backprop tensor (input)
+ * @param backprop              Data tensor backprop (output)
+ * @param is_contiguous         Contiguous or non-contiguous (input)
+ * @return                      miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
+                                           void* workspace,
+                                           size_t workspaceSizeInBytes,
+                                           const miopenTensorDescriptor_t inputDesc,
+                                           const void* input,
+                                           const miopenTensorDescriptor_t targetDesc,
+                                           const void* target,
+                                           const miopenTensorDescriptor_t outputDesc,
+                                           void* output,
+                                           const miopenTensorDescriptor_t backpropDesc,
+                                           void* backprop,
+                                           const miopenLossContiguousMode_t is_contiguous);
+
+/*! @brief Helper function to query the minimum workspace size required by the
+ * SoftmaxCrossEntropyWithLogits Backward call
+ *
+ * @param handle                   MIOpen Handle (input)
+ * @param outputGradDesc           Tensor descriptor for output grad tensor (input)
+ * @param backpropDesc             Tensor descriptor for backprop tensor (input)
+ * @param inputDesc                Tensor descriptor for input tensor (input)
+ * @param inputGradDesc            Tensor descriptor for input grad tensor (input)
+ * @param targetGradDesc           Tensor descriptor for target grad tensor (input)
+ * @param sizeInBytes              Pointer to data to return the minimum workspace size (output)
+ * @param is_contiguous            Contiguous or non-contiguous (input)
+ * @return                         miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(
+    miopenHandle_t handle,
+    const miopenTensorDescriptor_t outputGradDesc,
+    const miopenTensorDescriptor_t backpropDesc,
+    const miopenTensorDescriptor_t inputDesc,
+    const miopenTensorDescriptor_t inputGradDesc,
+    const miopenTensorDescriptor_t targetGradDesc,
+    size_t* sizeInBytes,
+    const miopenLossContiguousMode_t is_contiguous);
+
+/*! @brief Execute a softmaxcrossentropywithlogits backward layer
+ *
+ * @param handle                   MIOpen handle (input)
+ * @param workspace                Pointer to workspace (input)
+ * @param workspaceSizeInBytes     Size of workspace buffer (input)
+ * @param outputGradDesc           Tensor descriptor for output grad tensor (input)
+ * @param output_grad              Data tensor output grad (input)
+ * @param backpropDesc             Tensor descriptor for backprop tensor (input)
+ * @param backprop                 Data tensor backprop (input)
+ * @param inputDesc                Tensor descriptor for input tensor (input)
+ * @param input                    Data tensor input (input)
+ * @param inputGradDesc            Tensor descriptor for input grad tensor (input)
+ * @param input_grad               Data tensor input grad (output)
+ * @param targetGradDesc           Tensor descriptor for target grad tensor (input)
+ * @param target_grad              Data tensor target grad (output)
+ * @param is_contiguous            Contiguous or non-contiguous (input)
+ * @return                         miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenSoftmaxCrossEntropyWithLogitsBackward(miopenHandle_t handle,
+                                            void* workspace,
+                                            size_t workspaceSizeInBytes,
+                                            const miopenTensorDescriptor_t outputGradDesc,
+                                            const void* output_grad,
+                                            const miopenTensorDescriptor_t backpropDesc,
+                                            const void* backprop,
+                                            const miopenTensorDescriptor_t inputDesc,
+                                            const void* input,
+                                            const miopenTensorDescriptor_t inputGradDesc,
+                                            void* input_grad,
+                                            const miopenTensorDescriptor_t targetGradDesc,
+                                            void* target_grad,
+                                            const miopenLossContiguousMode_t is_contiguous);
+
+/** @} */
+// CLOSEOUT SoftmaxCrossEntropyWithLogits DOXYGEN GROUP
 #endif // MIOPEN_BETA_API
 
 #ifdef __cplusplus

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -474,8 +474,8 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         kernels/MIOpenConv1x1J1_stride.cl
         kernels/MIOpenSoftmax.cl
         kernels/MIOpenSoftmaxAttn.cpp
-        kernels/MIOpenSum.cpp
         kernels/MIOpenSoftmaxCrossEntropyWithLogits.cpp
+        kernels/MIOpenSum.cpp
         kernels/MIOpenUtilKernels3.cl
         kernels/MIOpenUtilKernels4.cl
         kernels/MIOpenUtilKernels5.cl

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -161,6 +161,8 @@ set( MIOpen_Source
     softmax.cpp
     softmax_api.cpp
     softmax/problem_description.cpp
+    softmaxcrossentropywithlogits_api.cpp
+    softmaxcrossentropywithlogits/problem_description.cpp
     solution.cpp
     solver.cpp
     solver/activ/bwd_0.cpp
@@ -273,6 +275,8 @@ set( MIOpen_Source
     solver/reduce/forward_sum.cpp
     solver/softmax/attn_softmax.cpp
     solver/softmax/softmax.cpp
+    solver/softmaxcrossentropywithlogits/fwd_con_softmaxcrossentropywithlogits.cpp
+    solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
     subbuffers.cpp
     sum_api.cpp
     target_properties.cpp
@@ -421,6 +425,7 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         kernels/neuron.inc
         kernels/rocm_version.inc
         kernels/stride_array.hpp
+        kernels/tensor_view.hpp
         kernels/utilities.inc
         kernels/workaround_issue_1431.hpp
         kernels/xform_bidirect_winograd_code.inc
@@ -470,6 +475,7 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         kernels/MIOpenSoftmax.cl
         kernels/MIOpenSoftmaxAttn.cpp
         kernels/MIOpenSum.cpp
+        kernels/MIOpenSoftmaxCrossEntropyWithLogits.cpp
         kernels/MIOpenUtilKernels3.cl
         kernels/MIOpenUtilKernels4.cl
         kernels/MIOpenUtilKernels5.cl
@@ -604,6 +610,7 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         ocl/fusionopconvocl.cpp
         ocl/fusionopbiasbnactivocl.cpp
         sum.cpp
+        softmaxcrossentropywithlogits.cpp
         ${PROJECT_BINARY_DIR}/db_path.cpp
         )
 

--- a/src/include/miopen/softmaxcrossentropywithlogits.hpp
+++ b/src/include/miopen/softmaxcrossentropywithlogits.hpp
@@ -33,51 +33,45 @@ namespace miopen {
 struct Handle;
 struct TensorDescriptor;
 
-size_t GetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(
-    Handle& handle,
-    const TensorDescriptor inputDesc,
-    const TensorDescriptor targetDesc,
-    const TensorDescriptor outputDesc,
-    const TensorDescriptor backpropDesc,
-    const miopenLossContiguousMode_t is_contiguous);
+size_t GetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(Handle& handle,
+                                                            const TensorDescriptor& inputDesc,
+                                                            const TensorDescriptor& targetDesc,
+                                                            const TensorDescriptor& outputDesc,
+                                                            const TensorDescriptor& backpropDesc);
 
 miopenStatus_t SoftmaxCrossEntropyWithLogitsForward(Handle& handle,
                                                     Data_t workspace,
                                                     size_t workspaceSizeInBytes,
-                                                    const TensorDescriptor inputDesc,
+                                                    const TensorDescriptor& inputDesc,
                                                     ConstData_t input,
-                                                    const TensorDescriptor targetDesc,
+                                                    const TensorDescriptor& targetDesc,
                                                     ConstData_t target,
-                                                    const TensorDescriptor outputDesc,
+                                                    const TensorDescriptor& outputDesc,
                                                     Data_t output,
-                                                    const TensorDescriptor backpropDesc,
-                                                    Data_t backprop,
-                                                    const miopenLossContiguousMode_t is_contiguous);
+                                                    const TensorDescriptor& backpropDesc,
+                                                    Data_t backprop);
 
-size_t GetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(
-    Handle& handle,
-    const TensorDescriptor outputGradDesc,
-    const TensorDescriptor backpropDesc,
-    const TensorDescriptor inputDesc,
-    const TensorDescriptor inputGradDesc,
-    const TensorDescriptor targetGradDesc,
-    const miopenLossContiguousMode_t is_contiguous);
+size_t
+GetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(Handle& handle,
+                                                      const TensorDescriptor& outputGradDesc,
+                                                      const TensorDescriptor& backpropDesc,
+                                                      const TensorDescriptor& inputDesc,
+                                                      const TensorDescriptor& inputGradDesc,
+                                                      const TensorDescriptor& targetGradDesc);
 
-miopenStatus_t
-SoftmaxCrossEntropyWithLogitsBackward(Handle& handle,
-                                      Data_t workspace,
-                                      size_t workspaceSizeInBytes,
-                                      const TensorDescriptor& outputGradDesc,
-                                      ConstData_t output_grad,
-                                      const TensorDescriptor& backpropDesc,
-                                      ConstData_t backprop,
-                                      const TensorDescriptor& inputDesc,
-                                      ConstData_t input,
-                                      const TensorDescriptor& inputGradDesc,
-                                      Data_t input_grad,
-                                      const TensorDescriptor& targetGradDesc,
-                                      Data_t target_grad,
-                                      const miopenLossContiguousMode_t is_contiguous);
+miopenStatus_t SoftmaxCrossEntropyWithLogitsBackward(Handle& handle,
+                                                     Data_t workspace,
+                                                     size_t workspaceSizeInBytes,
+                                                     const TensorDescriptor& outputGradDesc,
+                                                     ConstData_t output_grad,
+                                                     const TensorDescriptor& backpropDesc,
+                                                     ConstData_t backprop,
+                                                     const TensorDescriptor& inputDesc,
+                                                     ConstData_t input,
+                                                     const TensorDescriptor& inputGradDesc,
+                                                     Data_t input_grad,
+                                                     const TensorDescriptor& targetGradDesc,
+                                                     Data_t target_grad);
 
 } // namespace miopen
 #endif // MIOPEN_SOFTMAXCROSSENTROPYWITHLOGITS_HPP_

--- a/src/include/miopen/softmaxcrossentropywithlogits.hpp
+++ b/src/include/miopen/softmaxcrossentropywithlogits.hpp
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef MIOPEN_SOFTMAXCROSSENTROPYWITHLOGITS_HPP_
+#define MIOPEN_SOFTMAXCROSSENTROPYWITHLOGITS_HPP_
+
+#include <miopen/common.hpp>
+
+namespace miopen {
+
+struct Handle;
+struct TensorDescriptor;
+
+size_t GetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(
+    Handle& handle,
+    const TensorDescriptor inputDesc,
+    const TensorDescriptor targetDesc,
+    const TensorDescriptor outputDesc,
+    const TensorDescriptor backpropDesc,
+    const miopenLossContiguousMode_t is_contiguous);
+
+miopenStatus_t SoftmaxCrossEntropyWithLogitsForward(Handle& handle,
+                                                    Data_t workspace,
+                                                    size_t workspaceSizeInBytes,
+                                                    const TensorDescriptor inputDesc,
+                                                    ConstData_t input,
+                                                    const TensorDescriptor targetDesc,
+                                                    ConstData_t target,
+                                                    const TensorDescriptor outputDesc,
+                                                    Data_t output,
+                                                    const TensorDescriptor backpropDesc,
+                                                    Data_t backprop,
+                                                    const miopenLossContiguousMode_t is_contiguous);
+
+size_t GetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(
+    Handle& handle,
+    const TensorDescriptor outputGradDesc,
+    const TensorDescriptor backpropDesc,
+    const TensorDescriptor inputDesc,
+    const TensorDescriptor inputGradDesc,
+    const TensorDescriptor targetGradDesc,
+    const miopenLossContiguousMode_t is_contiguous);
+
+miopenStatus_t
+SoftmaxCrossEntropyWithLogitsBackward(Handle& handle,
+                                      Data_t workspace,
+                                      size_t workspaceSizeInBytes,
+                                      const TensorDescriptor& outputGradDesc,
+                                      ConstData_t output_grad,
+                                      const TensorDescriptor& backpropDesc,
+                                      ConstData_t backprop,
+                                      const TensorDescriptor& inputDesc,
+                                      ConstData_t input,
+                                      const TensorDescriptor& inputGradDesc,
+                                      Data_t input_grad,
+                                      const TensorDescriptor& targetGradDesc,
+                                      Data_t target_grad,
+                                      const miopenLossContiguousMode_t is_contiguous);
+
+} // namespace miopen
+#endif // MIOPEN_SOFTMAXCROSSENTROPYWITHLOGITS_HPP_

--- a/src/include/miopen/softmaxcrossentropywithlogits.hpp
+++ b/src/include/miopen/softmaxcrossentropywithlogits.hpp
@@ -33,15 +33,7 @@ namespace miopen {
 struct Handle;
 struct TensorDescriptor;
 
-size_t GetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(Handle& handle,
-                                                            const TensorDescriptor& inputDesc,
-                                                            const TensorDescriptor& targetDesc,
-                                                            const TensorDescriptor& outputDesc,
-                                                            const TensorDescriptor& backpropDesc);
-
 miopenStatus_t SoftmaxCrossEntropyWithLogitsForward(Handle& handle,
-                                                    Data_t workspace,
-                                                    size_t workspaceSizeInBytes,
                                                     const TensorDescriptor& inputDesc,
                                                     ConstData_t input,
                                                     const TensorDescriptor& targetDesc,
@@ -51,17 +43,7 @@ miopenStatus_t SoftmaxCrossEntropyWithLogitsForward(Handle& handle,
                                                     const TensorDescriptor& backpropDesc,
                                                     Data_t backprop);
 
-size_t
-GetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(Handle& handle,
-                                                      const TensorDescriptor& outputGradDesc,
-                                                      const TensorDescriptor& backpropDesc,
-                                                      const TensorDescriptor& inputDesc,
-                                                      const TensorDescriptor& inputGradDesc,
-                                                      const TensorDescriptor& targetGradDesc);
-
 miopenStatus_t SoftmaxCrossEntropyWithLogitsBackward(Handle& handle,
-                                                     Data_t workspace,
-                                                     size_t workspaceSizeInBytes,
                                                      const TensorDescriptor& outputGradDesc,
                                                      ConstData_t output_grad,
                                                      const TensorDescriptor& backpropDesc,

--- a/src/include/miopen/softmaxcrossentropywithlogits/invoke_params.hpp
+++ b/src/include/miopen/softmaxcrossentropywithlogits/invoke_params.hpp
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include "miopen/miopen.h"
+#include "miopen/common.hpp"
+#include <miopen/invoke_params.hpp>
+#include <miopen/tensor.hpp>
+
+#include <limits>
+
+namespace miopen {
+namespace softmaxcrossentropywithlogits {
+
+struct FwdInvokeParams : public miopen::InvokeParams
+{
+
+    FwdInvokeParams() = default;
+
+    const TensorDescriptor* inputDesc    = nullptr;
+    const TensorDescriptor* targetDesc   = nullptr;
+    const TensorDescriptor* outputDesc   = nullptr;
+    const TensorDescriptor* backpropDesc = nullptr;
+
+    ConstData_t input  = nullptr;
+    ConstData_t target = nullptr;
+    Data_t output      = nullptr;
+    Data_t backprop    = nullptr;
+
+    size_t workspaceSizeInBytes = 0;
+    Data_t workspace            = nullptr;
+
+    std::size_t GetWorkspaceSize() const { return workspaceSizeInBytes; }
+    Data_t GetWorkspace() const { return workspace; }
+};
+
+struct BwdInvokeParams : public miopen::InvokeParams
+{
+
+    BwdInvokeParams() = default;
+
+    const TensorDescriptor* outputGradDesc = nullptr;
+    const TensorDescriptor* backpropDesc   = nullptr;
+    const TensorDescriptor* inputDesc      = nullptr;
+    const TensorDescriptor* inputGradDesc  = nullptr;
+    const TensorDescriptor* targetGradDesc = nullptr;
+
+    ConstData_t output_grad = nullptr;
+    ConstData_t backprop    = nullptr;
+    ConstData_t input       = nullptr;
+    Data_t input_grad       = nullptr;
+    Data_t target_grad      = nullptr;
+
+    size_t workspaceSizeInBytes = 0;
+    Data_t workspace            = nullptr;
+
+    std::size_t GetWorkspaceSize() const { return workspaceSizeInBytes; }
+    Data_t GetWorkspace() const { return workspace; }
+};
+
+} // namespace softmaxcrossentropywithlogits
+} // namespace miopen

--- a/src/include/miopen/softmaxcrossentropywithlogits/invoke_params.hpp
+++ b/src/include/miopen/softmaxcrossentropywithlogits/invoke_params.hpp
@@ -51,11 +51,8 @@ struct FwdInvokeParams : public miopen::InvokeParams
     Data_t output      = nullptr;
     Data_t backprop    = nullptr;
 
-    size_t workspaceSizeInBytes = 0;
-    Data_t workspace            = nullptr;
-
-    std::size_t GetWorkspaceSize() const { return workspaceSizeInBytes; }
-    Data_t GetWorkspace() const { return workspace; }
+    std::size_t GetWorkspaceSize() const { return 0; }
+    Data_t GetWorkspace() const { return nullptr; }
 };
 
 struct BwdInvokeParams : public miopen::InvokeParams
@@ -75,11 +72,8 @@ struct BwdInvokeParams : public miopen::InvokeParams
     Data_t input_grad       = nullptr;
     Data_t target_grad      = nullptr;
 
-    size_t workspaceSizeInBytes = 0;
-    Data_t workspace            = nullptr;
-
-    std::size_t GetWorkspaceSize() const { return workspaceSizeInBytes; }
-    Data_t GetWorkspace() const { return workspace; }
+    std::size_t GetWorkspaceSize() const { return 0; }
+    Data_t GetWorkspace() const { return nullptr; }
 };
 
 } // namespace softmaxcrossentropywithlogits

--- a/src/include/miopen/softmaxcrossentropywithlogits/problem_description.hpp
+++ b/src/include/miopen/softmaxcrossentropywithlogits/problem_description.hpp
@@ -64,6 +64,18 @@ struct FwdProblemDescription : ProblemDescriptionBase
 
     bool IsValidLength() const
     {
+        if(inputDesc.GetSize() != 2 || targetDesc.GetSize() != 2 || backpropDesc.GetSize() != 2)
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "SoftmaxCrossEntropyWithLogits: Input, target, and backprop tensors size "
+                         "!= 2 is not valid.");
+        }
+
+        if(outputDesc.GetSize() != 1)
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "SoftmaxCrossEntropyWithLogits: Output tensor size != 1 is not valid.");
+        }
         if(inputDesc.GetLengths()[0] != outputDesc.GetLengths()[0])
         {
             MIOPEN_THROW(miopenStatusBadParm,
@@ -77,17 +89,6 @@ struct FwdProblemDescription : ProblemDescriptionBase
                 MIOPEN_THROW(miopenStatusBadParm,
                              "SoftmaxCrossEntropyWithLogits: Tensor sizes do not match.");
             }
-        }
-        if(inputDesc.GetSize() > 2 || targetDesc.GetSize() > 2 || backpropDesc.GetSize() > 2)
-        {
-            MIOPEN_THROW(miopenStatusBadParm,
-                         "SoftmaxCrossEntropyWithLogits: Input tensors size > 2 is not valid.");
-        }
-
-        if(outputDesc.GetSize() > 1)
-        {
-            MIOPEN_THROW(miopenStatusBadParm,
-                         "SoftmaxCrossEntropyWithLogits: Output tensor size > 1 is not valid.");
         }
         return true;
     }
@@ -175,6 +176,22 @@ struct BwdProblemDescription : ProblemDescriptionBase
 
     bool IsValidLength() const
     {
+        if(backpropDesc.GetSize() != 2 || inputDesc.GetSize() != 2 || inputGradDesc.GetSize() != 2)
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "SoftmaxCrossEntropyWithLogits: Input tensor size != 2 is not valid.");
+        }
+        if(targetGradDesc.GetSize() != 0 && targetGradDesc.GetSize() != 2)
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "SoftmaxCrossEntropyWithLogits: Target Grad tensor sizes is not valid.");
+        }
+        if(outputGradDesc.GetSize() != 1)
+        {
+            MIOPEN_THROW(
+                miopenStatusBadParm,
+                "SoftmaxCrossEntropyWithLogits: Output grad tensor size != 1 is not valid.");
+        }
         if(inputDesc.GetLengths()[0] != outputGradDesc.GetLengths()[0])
         {
             MIOPEN_THROW(miopenStatusBadParm,
@@ -183,25 +200,20 @@ struct BwdProblemDescription : ProblemDescriptionBase
         for(int i = 0; i < inputDesc.GetSize(); ++i)
         {
             if(inputDesc.GetLengths()[i] != backpropDesc.GetLengths()[i] ||
-               inputDesc.GetLengths()[i] != inputGradDesc.GetLengths()[i] ||
-               inputDesc.GetLengths()[i] != targetGradDesc.GetLengths()[i])
+               inputDesc.GetLengths()[i] != inputGradDesc.GetLengths()[i])
             {
                 MIOPEN_THROW(miopenStatusBadParm,
                              "SoftmaxCrossEntropyWithLogits: Tensor sizes do not match.");
             }
         }
-        if(backpropDesc.GetSize() > 2 || inputDesc.GetSize() > 2 || inputGradDesc.GetSize() > 2 ||
-           targetGradDesc.GetSize() > 2)
+        if(targetGradDesc.GetSize() == 2)
         {
-            MIOPEN_THROW(miopenStatusBadParm,
-                         "SoftmaxCrossEntropyWithLogits: Input tensor size > 2 is not valid.");
-        }
-
-        if(outputGradDesc.GetSize() > 1)
-        {
-            MIOPEN_THROW(
-                miopenStatusBadParm,
-                "SoftmaxCrossEntropyWithLogits: Output grad tensor size > 1 is not valid.");
+            if(inputDesc.GetLengths()[0] != targetGradDesc.GetLengths()[0] ||
+               inputDesc.GetLengths()[1] != targetGradDesc.GetLengths()[1])
+            {
+                MIOPEN_THROW(miopenStatusBadParm,
+                             "SoftmaxCrossEntropyWithLogits: Tensor sizes do not match.");
+            }
         }
         return true;
     }

--- a/src/include/miopen/softmaxcrossentropywithlogits/problem_description.hpp
+++ b/src/include/miopen/softmaxcrossentropywithlogits/problem_description.hpp
@@ -51,7 +51,6 @@ struct FwdProblemDescription : ProblemDescriptionBase
     {
         IsValidLength();
         IsAllValidStride();
-        IsTargetProb();
     }
 
     const TensorDescriptor& GetInputDesc() const { return inputDesc; }
@@ -138,14 +137,6 @@ struct FwdProblemDescription : ProblemDescriptionBase
                isContiguous(backpropDesc);
     }
 
-    bool IsTargetProb() const
-    {
-        // check if each batch of target represents a valid probability distribution
-        // i.e. sum of each batch of target is 1 and each element is in [0, 1]
-
-        return true;
-    }
-
     NetworkConfig MakeNetworkConfig() const override;
 
 protected:
@@ -178,6 +169,7 @@ struct BwdProblemDescription : ProblemDescriptionBase
     const TensorDescriptor& GetInputGradDesc() const { return inputGradDesc; }
     const TensorDescriptor& GetTargetGradDesc() const { return targetGradDesc; }
 
+    size_t GetBatchSize() const { return inputDesc.GetLengths()[0]; }
     size_t GetNumClasses() const { return inputDesc.GetLengths()[1]; }
     size_t GetInputTotal() const { return inputDesc.GetElementSize(); }
 

--- a/src/include/miopen/softmaxcrossentropywithlogits/problem_description.hpp
+++ b/src/include/miopen/softmaxcrossentropywithlogits/problem_description.hpp
@@ -1,0 +1,276 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include <miopen/problem_description_base.hpp>
+#include <miopen/activ.hpp>
+#include <miopen/tensor.hpp>
+#include <cassert>
+#include <string>
+
+namespace miopen {
+
+struct NetworkConfig;
+
+namespace softmaxcrossentropywithlogits {
+
+struct FwdProblemDescription : ProblemDescriptionBase
+{
+    FwdProblemDescription(const TensorDescriptor& inputDesc_,
+                          const TensorDescriptor& targetDesc_,
+                          const TensorDescriptor& outputDesc_,
+                          const TensorDescriptor& backpropDesc_)
+        : inputDesc(inputDesc_),
+          targetDesc(targetDesc_),
+          outputDesc(outputDesc_),
+          backpropDesc(backpropDesc_)
+    {
+        IsValidLength();
+        IsAllValidStride();
+        IsTargetProb();
+    }
+
+    const TensorDescriptor& GetInputDesc() const { return inputDesc; }
+    const TensorDescriptor& GetTargetDesc() const { return targetDesc; }
+    const TensorDescriptor& GetOutputDesc() const { return outputDesc; }
+    const TensorDescriptor& GetBackpropDesc() const { return backpropDesc; }
+
+    size_t GetBatchSize() const { return inputDesc.GetLengths()[0]; }
+    size_t GetNumClasses() const { return inputDesc.GetLengths()[1]; }
+    size_t GetInputTotal() const { return inputDesc.GetElementSize(); }
+
+    bool IsValidLength() const
+    {
+        if(inputDesc.GetLengths()[0] != outputDesc.GetLengths()[0])
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "SoftmaxCrossEntropyWithLogits: Tensor sizes do not match.");
+        }
+        for(int i = 0; i < inputDesc.GetSize(); ++i)
+        {
+            if(inputDesc.GetLengths()[i] != targetDesc.GetLengths()[i] ||
+               inputDesc.GetLengths()[i] != backpropDesc.GetLengths()[i])
+            {
+                MIOPEN_THROW(miopenStatusBadParm,
+                             "SoftmaxCrossEntropyWithLogits: Tensor sizes do not match.");
+            }
+        }
+        if(inputDesc.GetSize() > 2 || targetDesc.GetSize() > 2 || backpropDesc.GetSize() > 2)
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "SoftmaxCrossEntropyWithLogits: Input tensors size > 2 is not valid.");
+        }
+
+        if(outputDesc.GetSize() > 1)
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "SoftmaxCrossEntropyWithLogits: Output tensor size > 1 is not valid.");
+        }
+        return true;
+    }
+
+    bool IsValidStride(TensorDescriptor td) const
+    {
+        auto strides = td.GetStrides();
+        auto lengths = td.GetLengths();
+        std::vector<std::pair<size_t, size_t>> p;
+        p.reserve(td.GetSize());
+        std::transform(strides.begin(),
+                       strides.end(),
+                       lengths.begin(),
+                       std::back_inserter(p),
+                       [](size_t a, size_t b) { return std::make_pair(a, b); });
+        std::sort(p.begin(), p.end());
+        for(int i = 1; i < p.size(); ++i)
+        {
+            if(p[i].first != p[i - 1].first * p[i - 1].second)
+                MIOPEN_THROW(miopenStatusBadParm,
+                             "SoftmaxCrossEntropyWithLogits: Tensor strides do not valid.");
+        }
+        return true;
+    }
+
+    bool IsAllValidStride() const
+    {
+        return IsValidStride(inputDesc) && IsValidStride(targetDesc) && IsValidStride(outputDesc) &&
+               IsValidStride(backpropDesc);
+    }
+
+    bool IsAllContiguous() const
+    {
+        auto isContiguous = [](TensorDescriptor td) {
+            size_t s = 1;
+            for(int i = td.GetSize() - 1; i >= 0; --i)
+            {
+                if(s != td.GetStrides()[i])
+                {
+                    return false;
+                }
+                s *= td.GetLengths()[i];
+            }
+            return true;
+        };
+        return isContiguous(inputDesc) && isContiguous(targetDesc) && isContiguous(outputDesc) &&
+               isContiguous(backpropDesc);
+    }
+
+    bool IsTargetProb() const
+    {
+        // check if each batch of target represents a valid probability distribution
+        // i.e. sum of each batch of target is 1 and each element is in [0, 1]
+
+        return true;
+    }
+
+    NetworkConfig MakeNetworkConfig() const override;
+
+protected:
+    TensorDescriptor inputDesc;
+    TensorDescriptor targetDesc;
+    TensorDescriptor outputDesc;
+    TensorDescriptor backpropDesc;
+};
+
+struct BwdProblemDescription : ProblemDescriptionBase
+{
+    BwdProblemDescription(const TensorDescriptor& outputGradDesc_,
+                          const TensorDescriptor& backpropDesc_,
+                          const TensorDescriptor& inputDesc_,
+                          const TensorDescriptor& inputGradDesc_,
+                          const TensorDescriptor& targetGradDesc_)
+        : outputGradDesc(outputGradDesc_),
+          backpropDesc(backpropDesc_),
+          inputDesc(inputDesc_),
+          inputGradDesc(inputGradDesc_),
+          targetGradDesc(targetGradDesc_)
+    {
+        IsValidLength();
+        IsAllValidStride();
+    }
+
+    const TensorDescriptor& GetOutputGradDesc() const { return outputGradDesc; }
+    const TensorDescriptor& GetBackpropDesc() const { return backpropDesc; }
+    const TensorDescriptor& GetInputDesc() const { return inputDesc; }
+    const TensorDescriptor& GetInputGradDesc() const { return inputGradDesc; }
+    const TensorDescriptor& GetTargetGradDesc() const { return targetGradDesc; }
+
+    size_t GetNumClasses() const { return inputDesc.GetLengths()[1]; }
+    size_t GetInputTotal() const { return inputDesc.GetElementSize(); }
+
+    bool IsValidLength() const
+    {
+        if(inputDesc.GetLengths()[0] != outputGradDesc.GetLengths()[0])
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "SoftmaxCrossEntropyWithLogits: Tensor sizes do not match.");
+        }
+        for(int i = 0; i < inputDesc.GetSize(); ++i)
+        {
+            if(inputDesc.GetLengths()[i] != backpropDesc.GetLengths()[i] ||
+               inputDesc.GetLengths()[i] != inputGradDesc.GetLengths()[i] ||
+               inputDesc.GetLengths()[i] != targetGradDesc.GetLengths()[i])
+            {
+                MIOPEN_THROW(miopenStatusBadParm,
+                             "SoftmaxCrossEntropyWithLogits: Tensor sizes do not match.");
+            }
+        }
+        if(backpropDesc.GetSize() > 2 || inputDesc.GetSize() > 2 || inputGradDesc.GetSize() > 2 ||
+           targetGradDesc.GetSize() > 2)
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "SoftmaxCrossEntropyWithLogits: Input tensor size > 2 is not valid.");
+        }
+
+        if(outputGradDesc.GetSize() > 1)
+        {
+            MIOPEN_THROW(
+                miopenStatusBadParm,
+                "SoftmaxCrossEntropyWithLogits: Output grad tensor size > 1 is not valid.");
+        }
+        return true;
+    }
+
+    bool IsValidStride(TensorDescriptor td) const
+    {
+        auto strides = td.GetStrides();
+        auto lengths = td.GetLengths();
+        std::vector<std::pair<size_t, size_t>> p;
+        p.reserve(td.GetSize());
+        std::transform(strides.begin(),
+                       strides.end(),
+                       lengths.begin(),
+                       std::back_inserter(p),
+                       [](size_t a, size_t b) { return std::make_pair(a, b); });
+        std::sort(p.begin(), p.end());
+        for(int i = 1; i < p.size(); ++i)
+        {
+            if(p[i].first != p[i - 1].first * p[i - 1].second)
+                MIOPEN_THROW(miopenStatusBadParm,
+                             "SoftmaxCrossEntropyWithLogits: Tensor strides do not valid.");
+        }
+        return true;
+    }
+
+    bool IsAllValidStride() const
+    {
+        return IsValidStride(outputGradDesc) && IsValidStride(backpropDesc) &&
+               IsValidStride(inputDesc) && IsValidStride(inputGradDesc) &&
+               IsValidStride(targetGradDesc);
+    }
+
+    bool IsAllContiguous() const
+    {
+        auto isContiguous = [](TensorDescriptor td) {
+            size_t s = 1;
+            for(int i = td.GetSize() - 1; i >= 0; --i)
+            {
+                if(s != td.GetStrides()[i])
+                {
+                    return false;
+                }
+                s *= td.GetLengths()[i];
+            }
+            return true;
+        };
+        return isContiguous(outputGradDesc) && isContiguous(backpropDesc) &&
+               isContiguous(inputDesc) && isContiguous(inputGradDesc) &&
+               isContiguous(targetGradDesc);
+    }
+
+    NetworkConfig MakeNetworkConfig() const override;
+
+protected:
+    TensorDescriptor outputGradDesc;
+    TensorDescriptor backpropDesc;
+    TensorDescriptor inputDesc;
+    TensorDescriptor inputGradDesc;
+    TensorDescriptor targetGradDesc;
+};
+
+} // namespace softmaxcrossentropywithlogits
+
+} // namespace miopen

--- a/src/include/miopen/softmaxcrossentropywithlogits/solvers.hpp
+++ b/src/include/miopen/softmaxcrossentropywithlogits/solvers.hpp
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include "miopen/conv_solution.hpp"
+#include "miopen/execution_context.hpp"
+#include <miopen/solver.hpp>
+#include <miopen/softmaxcrossentropywithlogits/problem_description.hpp>
+#include "miopen/kernel_build_params.hpp"
+#include "miopen/kernel_info.hpp"
+
+#include <utility>
+
+namespace miopen {
+
+namespace solver {
+
+const auto make_hip_kernel = [](std::vector<size_t> localsize,
+                                std::vector<size_t> gridsize,
+                                std::string kernel_file,
+                                std::string kernel_name,
+                                KernelBuildParameters build_params) {
+    while(localsize.size() < 3)
+        localsize.push_back(1);
+    while(gridsize.size() < 3)
+        gridsize.push_back(1);
+    for(int i = 0; i < localsize.size(); ++i)
+        gridsize[i] = AlignUp(gridsize[i], localsize[i]);
+    return KernelInfo{
+        build_params.GenerateFor(kbp::HIP{}), localsize, gridsize, kernel_file, kernel_name};
+};
+
+namespace softmaxcrossentropywithlogits {
+
+using SoftmaxCrossEntropyWithLogitsFwdSolver =
+    NonTunableSolverBase<ExecutionContext,
+                         miopen::softmaxcrossentropywithlogits::FwdProblemDescription>;
+
+using SoftmaxCrossEntropyWithLogitsBwdSolver =
+    NonTunableSolverBase<ExecutionContext,
+                         miopen::softmaxcrossentropywithlogits::BwdProblemDescription>;
+
+// FORWARD CONTIGUOUS
+struct SoftmaxCrossEntropyWithLogitsForwardContiguous final : SoftmaxCrossEntropyWithLogitsFwdSolver
+{
+    const std::string& SolverDbId() const override
+    {
+        return GetSolverDbId<SoftmaxCrossEntropyWithLogitsForwardContiguous>();
+    }
+
+    bool IsApplicable(
+        const ExecutionContext& context,
+        const miopen::softmaxcrossentropywithlogits::FwdProblemDescription& problem) const override;
+
+    ConvSolution GetSolution(
+        const ExecutionContext& context,
+        const miopen::softmaxcrossentropywithlogits::FwdProblemDescription& problem) const override;
+
+    bool MayNeedWorkspace() const override { return true; }
+};
+
+// BACKWARD CONTIGUOUS
+struct SoftmaxCrossEntropyWithLogitsBackwardContiguous final
+    : SoftmaxCrossEntropyWithLogitsBwdSolver
+{
+    const std::string& SolverDbId() const override
+    {
+        return GetSolverDbId<SoftmaxCrossEntropyWithLogitsBackwardContiguous>();
+    }
+
+    bool IsApplicable(
+        const ExecutionContext& context,
+        const miopen::softmaxcrossentropywithlogits::BwdProblemDescription& problem) const override;
+
+    ConvSolution GetSolution(
+        const ExecutionContext& context,
+        const miopen::softmaxcrossentropywithlogits::BwdProblemDescription& problem) const override;
+
+    bool MayNeedWorkspace() const override { return true; }
+};
+
+} // namespace softmaxcrossentropywithlogits
+
+} // namespace solver
+
+} // namespace miopen

--- a/src/include/miopen/softmaxcrossentropywithlogits/solvers.hpp
+++ b/src/include/miopen/softmaxcrossentropywithlogits/solvers.hpp
@@ -79,8 +79,6 @@ struct SoftmaxCrossEntropyWithLogitsForwardContiguous final : SoftmaxCrossEntrop
     ConvSolution GetSolution(
         const ExecutionContext& context,
         const miopen::softmaxcrossentropywithlogits::FwdProblemDescription& problem) const override;
-
-    bool MayNeedWorkspace() const override { return true; }
 };
 
 // BACKWARD CONTIGUOUS
@@ -99,8 +97,6 @@ struct SoftmaxCrossEntropyWithLogitsBackwardContiguous final
     ConvSolution GetSolution(
         const ExecutionContext& context,
         const miopen::softmaxcrossentropywithlogits::BwdProblemDescription& problem) const override;
-
-    bool MayNeedWorkspace() const override { return true; }
 };
 
 } // namespace softmaxcrossentropywithlogits

--- a/src/include/miopen/solver_id.hpp
+++ b/src/include/miopen/solver_id.hpp
@@ -56,7 +56,8 @@ enum class Primitive
     Reduce,
     Cat,
     Mha,
-    Softmax
+    Softmax,
+    SoftmaxCrossEntropyWithLogits
 };
 
 struct MIOPEN_EXPORT Id

--- a/src/include/miopen/tensor_view.hpp
+++ b/src/include/miopen/tensor_view.hpp
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef GUARD_TENSOR_VIEW_H
+#define GUARD_TENSOR_VIEW_H
+
+#include "miopen/tensor.hpp"
+
+using tensor_view_1d_t = struct
+{
+    uint64_t stride[1];
+    uint64_t size[1];
+};
+
+using tensor_view_2d_t = struct
+{
+    uint64_t stride[2];
+    uint64_t size[2];
+};
+
+using tensor_view_3d_t = struct
+{
+    uint64_t stride[3];
+    uint64_t size[3];
+};
+
+using tensor_view_4d_t = struct
+{
+    uint64_t stride[4];
+    uint64_t size[4];
+};
+
+using tensor_view_5d_t = struct
+{
+    uint64_t stride[5];
+    uint64_t size[5];
+};
+
+#define TV_IDX(tv, d, n) (tv.stride[d] * (n))
+
+#define TV1D_IDX(tv, n0) (TV_IDX(tv, 0, n0))
+
+#define TV2D_IDX(tv, n0, n1) (TV_IDX(tv, 1, n1) + TV1D_IDX(tv, n0))
+
+#define TV3D_IDX(tv, n0, n1, n2) (TV_IDX(tv, 2, n2) + TV2D_IDX(tv, n0, n1))
+
+#define TV4D_IDX(tv, n0, n1, n2, n3) (TV_IDX(tv, 3, n3) + TV3D_IDX(tv, n0, n1, n2))
+
+#define TV5D_IDX(tv, n0, n1, n2, n3, n4) (TV_IDX(tv, 4, n4) + TV4D_IDX(tv, n0, n1, n2, n3))
+
+#define TV_1D_AT(x, idx) (x[IDX_TO_TV1D_IDX(x##_tv, idx)])
+#define TV_2D_AT(x, n0, n1) (x[TV2D_IDX(x##_tv, n0, n1)])
+#define TV_3D_AT(x, n0, n1, n2) (x[TV3D_IDX(x##_tv, n0, n1, n2)])
+#define TV_4D_AT(x, n0, n1, n2, n3) (x[TV4D_IDX(x##_tv, n0, n1, n2, n3)])
+#define TV_5D_AT(x, n0, n1, n2, n3, n4) (x[TV5D_IDX(x##_tv, n0, n1, n2, n3, n4)])
+
+#define GET_NCDHW(n, c, d, h, w, idx, tv) \
+    {                                     \
+        ulong ncdh = (idx) / tv.size[4];  \
+        w          = (idx) % tv.size[4];  \
+        ulong ncd  = ncdh / tv.size[3];   \
+        h          = ncdh % tv.size[3];   \
+        ulong nc   = ncd / tv.size[2];    \
+        d          = ncd % tv.size[2];    \
+        n          = nc / tv.size[1];     \
+        c          = nc % tv.size[1];     \
+    }
+
+#define GET_NCDH(n, c, d, h, idx, tv)   \
+    {                                   \
+        ulong ncd = (idx) / tv.size[3]; \
+        h         = (idx) % tv.size[3]; \
+        ulong nc  = ncd / tv.size[2];   \
+        d         = ncd % tv.size[2];   \
+        n         = nc / tv.size[1];    \
+        c         = nc % tv.size[1];    \
+    }
+
+#define GET_NCD(n, c, d, idx, tv)      \
+    {                                  \
+        ulong nc = (idx) / tv.size[2]; \
+        d        = (idx) % tv.size[2]; \
+        n        = nc / tv.size[1];    \
+        c        = nc % tv.size[1];    \
+    }
+
+inline tensor_view_1d_t get_inner_expanded_tv_1d(const miopen::TensorDescriptor Desc)
+{
+    auto dims    = Desc.GetLengths();
+    auto strides = Desc.GetStrides();
+
+    tensor_view_1d_t tv_1d;
+    for(size_t i = 0; i < strides.size(); ++i)
+    {
+        tv_1d.stride[i] = strides[i];
+        tv_1d.size[i]   = dims[i];
+    }
+    auto rest = strides.size();
+    for(size_t j = rest; j < 1; ++j)
+    {
+        tv_1d.stride[j] = (rest == 0 ? 1 : strides[rest - 1]);
+        tv_1d.size[j]   = 1;
+    }
+    return tv_1d;
+}
+
+inline tensor_view_2d_t get_inner_expanded_tv_2d(const miopen::TensorDescriptor Desc)
+{
+    auto dims    = Desc.GetLengths();
+    auto strides = Desc.GetStrides();
+
+    tensor_view_2d_t tv_2d;
+    for(size_t i = 0; i < strides.size(); ++i)
+    {
+        tv_2d.stride[i] = strides[i];
+        tv_2d.size[i]   = dims[i];
+    }
+    auto rest = strides.size();
+    for(size_t j = rest; j < 2; ++j)
+    {
+        tv_2d.stride[j] = (rest == 0 ? 1 : strides[rest - 1]);
+        tv_2d.size[j]   = 1;
+    }
+    return tv_2d;
+}
+
+inline tensor_view_3d_t get_inner_expanded_tv_3d(const miopen::TensorDescriptor Desc)
+{
+    auto dims    = Desc.GetLengths();
+    auto strides = Desc.GetStrides();
+
+    tensor_view_3d_t tv_3d;
+    for(size_t i = 0; i < strides.size(); ++i)
+    {
+        tv_3d.stride[i] = strides[i];
+        tv_3d.size[i]   = dims[i];
+    }
+    auto rest = strides.size();
+    for(size_t j = rest; j < 3; ++j)
+    {
+        tv_3d.stride[j] = (rest == 0 ? 1 : strides[rest - 1]);
+        tv_3d.size[j]   = 1;
+    }
+    return tv_3d;
+}
+
+inline tensor_view_4d_t get_inner_expanded_tv_4d(const miopen::TensorDescriptor Desc)
+{
+    auto dims    = Desc.GetLengths();
+    auto strides = Desc.GetStrides();
+
+    tensor_view_4d_t tv_4d;
+    for(size_t i = 0; i < strides.size(); ++i)
+    {
+        tv_4d.stride[i] = strides[i];
+        tv_4d.size[i]   = dims[i];
+    }
+    auto rest = strides.size();
+    for(size_t j = rest; j < 4; ++j)
+    {
+        tv_4d.stride[j] = (rest == 0 ? 1 : strides[rest - 1]);
+        tv_4d.size[j]   = 1;
+    }
+    return tv_4d;
+}
+
+inline tensor_view_5d_t get_inner_expanded_tv_5d(const miopen::TensorDescriptor Desc)
+{
+    auto dims    = Desc.GetLengths();
+    auto strides = Desc.GetStrides();
+
+    tensor_view_5d_t tv_5d;
+    for(size_t i = 0; i < strides.size(); ++i)
+    {
+        tv_5d.stride[i] = strides[i];
+        tv_5d.size[i]   = dims[i];
+    }
+    auto rest = strides.size();
+    for(size_t j = rest; j < 5; ++j)
+    {
+        tv_5d.stride[j] = (rest == 0 ? 1 : strides[rest - 1]);
+        tv_5d.size[j]   = 1;
+    }
+    return tv_5d;
+}
+
+#endif // GUARD_TENSOR_VIEW_H

--- a/src/kernels/MIOpenSoftmaxCrossEntropyWithLogits.cpp
+++ b/src/kernels/MIOpenSoftmaxCrossEntropyWithLogits.cpp
@@ -1,0 +1,243 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#endif
+
+#include "float_types.h"
+#include "tensor_view.hpp"
+
+#ifndef LOCAL_SIZE
+#define LOCAL_SIZE 256
+#endif
+
+template <typename TI, typename TO>
+__device__ void softmaxcrossentropywithlogitsForwardContiguous(const TI* __restrict__ input,
+                                                               const TI* __restrict__ target,
+                                                               TO* __restrict__ output,
+                                                               TO* __restrict__ backprop,
+                                                               tensor_view_2d_t input_tv,
+                                                               tensor_view_2d_t target_tv,
+                                                               tensor_view_1d_t output_tv,
+                                                               tensor_view_2d_t backprop_tv)
+{
+    uint64_t gid     = threadIdx.x + blockIdx.x * blockDim.x;
+    uint64_t lid     = threadIdx.x;
+    size_t num_class = input_tv.size[1];
+
+    //   __local FLOAT_ACCUM lmax[LOCAL_SIZE], lsum[LOCAL_SIZE], lloss[LOCAL_SIZE];
+    FLOAT_ACCUM lmax[LOCAL_SIZE], lsum[LOCAL_SIZE], lloss[LOCAL_SIZE];
+    lmax[lid]           = -std::numeric_limits<FLOAT_ACCUM>::infinity();
+    lsum[lid]           = 0.0f;
+    lloss[lid]          = 0.0f;
+    size_t batch_offset = gid * num_class;
+
+    for(int i = lid; i < num_class; i += LOCAL_SIZE)
+    {
+        FLOAT_ACCUM val = CVT_FLOAT2ACCUM(input[i + batch_offset]);
+        lmax[lid]       = max(lmax[lid], val);
+    }
+    __syncthreads();
+
+    for(int i = LOCAL_SIZE >> 1; i > 0; i >>= 1)
+    {
+        if(lid < i)
+        {
+            lmax[lid] = max(lmax[lid], lmax[lid + i]);
+        }
+        __syncthreads();
+    }
+
+    for(int i = lid; i < num_class; i += LOCAL_SIZE)
+    {
+        FLOAT_ACCUM val = CVT_FLOAT2ACCUM(input[i + batch_offset]);
+        lsum[lid] += exp(val - lmax[0]);
+    }
+    __syncthreads();
+
+    for(int i = LOCAL_SIZE >> 1; i > 0; i >>= 1)
+    {
+        if(lid < i)
+        {
+            lsum[lid] += lsum[lid + i];
+        }
+        __syncthreads();
+    }
+
+    FLOAT_ACCUM log_val = log(lsum[0]);
+    for(int i = lid; i < num_class; i += LOCAL_SIZE)
+    {
+        FLOAT_ACCUM val   = CVT_FLOAT2ACCUM(input[i + batch_offset]);
+        FLOAT_ACCUM label = CVT_FLOAT2ACCUM(target[i + batch_offset]);
+        lloss[lid] += label * (log_val - val + lmax[0]);
+    }
+    __syncthreads();
+
+    for(int i = LOCAL_SIZE >> 1; i > 0; i >>= 1)
+    {
+        if(lid < i)
+        {
+            lloss[lid] += lloss[lid + i];
+        }
+        __syncthreads();
+    }
+
+    if(lid == 0)
+    {
+        output[gid] = CVT_ACCUM2FLOAT(lloss[0]);
+    }
+
+    for(int i = lid; i < num_class; i += LOCAL_SIZE)
+    {
+        FLOAT_ACCUM val            = CVT_FLOAT2ACCUM(input[i + batch_offset]);
+        FLOAT_ACCUM label          = CVT_FLOAT2ACCUM(target[i + batch_offset]);
+        FLOAT_ACCUM backprop_val   = exp(val - lmax[0]) / lsum[0] - label;
+        backprop[i + batch_offset] = CVT_ACCUM2FLOAT(backprop_val);
+    }
+}
+
+extern "C" __global__ void
+SoftmaxCrossEntropyWithLogitsForwardContiguous(const INPUT_TYPE* __restrict__ input,
+                                               const INPUT_TYPE* __restrict__ target,
+                                               OUTPUT_TYPE* __restrict__ output,
+                                               OUTPUT_TYPE* __restrict__ backprop,
+                                               tensor_view_2d_t input_tv,
+                                               tensor_view_2d_t target_tv,
+                                               tensor_view_1d_t output_tv,
+                                               tensor_view_2d_t backprop_tv)
+{
+    softmaxcrossentropywithlogitsForwardContiguous<INPUT_TYPE, OUTPUT_TYPE>(
+        input, target, output, backprop, input_tv, target_tv, output_tv, backprop_tv);
+}
+
+template <typename TI, typename TO>
+__device__ void softmaxcrossentropywithlogitsBackwardContiguous(const TI* __restrict__ output_grad,
+                                                                const TI* __restrict__ backprop,
+                                                                const TI* __restrict__ input,
+                                                                TO* __restrict__ input_grad,
+                                                                TO* __restrict__ target_grad,
+                                                                tensor_view_1d_t output_grad_tv,
+                                                                tensor_view_2d_t backprop_tv,
+                                                                tensor_view_2d_t input_tv,
+                                                                tensor_view_2d_t input_grad_tv,
+                                                                tensor_view_2d_t target_grad_tv)
+{
+    uint64_t gid     = threadIdx.x + blockIdx.x * blockDim.x;
+    uint64_t lid     = threadIdx.x;
+    size_t num_class = input_tv.size[1];
+
+    size_t batch_offset = gid * num_class;
+
+    // __local FSTYPE lmax[LOCAL_SIZE], lsum[LOCAL_SIZE];
+    FLOAT_ACCUM lmax[LOCAL_SIZE], lsum[LOCAL_SIZE];
+    lmax[lid] = -std::numeric_limits<FLOAT_ACCUM>::infinity();
+    lsum[lid] = 0.0f;
+
+    // __local DTYPE output_grad_val;
+    FLOAT_ACCUM output_grad_val;
+    if(lid == 0)
+    {
+        output_grad_val = CVT_FLOAT2ACCUM(output_grad[gid]);
+    }
+    __syncthreads();
+
+    if(input_grad)
+    {
+        for(int i = lid; i < num_class; i += LOCAL_SIZE)
+        {
+            FLOAT_ACCUM backprop_val     = CVT_FLOAT2ACCUM(backprop[i + batch_offset]);
+            input_grad[i + batch_offset] = CVT_ACCUM2FLOAT(output_grad_val * backprop_val);
+        }
+    }
+
+    if(target_grad)
+    {
+        for(int i = lid; i < num_class; i += LOCAL_SIZE)
+        {
+            FLOAT_ACCUM val = CVT_FLOAT2ACCUM(input[i + batch_offset]);
+            lmax[lid]       = max(lmax[lid], val);
+        }
+        __syncthreads();
+
+        for(int i = LOCAL_SIZE >> 1; i > 0; i >>= 1)
+        {
+            if(lid < i)
+            {
+                lmax[lid] = max(lmax[lid], lmax[lid + i]);
+            }
+            __syncthreads();
+        }
+
+        for(int i = lid; i < num_class; i += LOCAL_SIZE)
+        {
+            FLOAT_ACCUM val = CVT_FLOAT2ACCUM(input[i + batch_offset]);
+            lsum[lid] += exp(val - lmax[0]);
+        }
+        __syncthreads();
+
+        for(int i = LOCAL_SIZE >> 1; i > 0; i >>= 1)
+        {
+            if(lid < i)
+            {
+                lsum[lid] += lsum[lid + i];
+            }
+            __syncthreads();
+        }
+
+        FLOAT_ACCUM log_val = log(lsum[0]);
+        for(int i = lid; i < num_class; i += LOCAL_SIZE)
+        {
+            FLOAT_ACCUM logit_val = CVT_FLOAT2ACCUM(input[i + batch_offset]);
+            target_grad[i + batch_offset] =
+                CVT_ACCUM2FLOAT((lmax[0] + log_val - logit_val) * output_grad_val);
+        }
+    }
+}
+
+extern "C" __global__ void
+SoftmaxCrossEntropyWithLogitsBackwardContiguous(const INPUT_TYPE* __restrict__ output_grad,
+                                                const INPUT_TYPE* __restrict__ backprop,
+                                                const INPUT_TYPE* __restrict__ input,
+                                                OUTPUT_TYPE* __restrict__ input_grad,
+                                                OUTPUT_TYPE* __restrict__ target_grad,
+                                                tensor_view_1d_t output_grad_tv,
+                                                tensor_view_2d_t backprop_tv,
+                                                tensor_view_2d_t input_tv,
+                                                tensor_view_2d_t input_grad_tv,
+                                                tensor_view_2d_t target_grad_tv)
+{
+    softmaxcrossentropywithlogitsBackwardContiguous<INPUT_TYPE, OUTPUT_TYPE>(output_grad,
+                                                                             backprop,
+                                                                             input,
+                                                                             input_grad,
+                                                                             target_grad,
+                                                                             output_grad_tv,
+                                                                             backprop_tv,
+                                                                             input_tv,
+                                                                             input_grad_tv,
+                                                                             target_grad_tv);
+}

--- a/src/kernels/MIOpenSoftmaxCrossEntropyWithLogits.cpp
+++ b/src/kernels/MIOpenSoftmaxCrossEntropyWithLogits.cpp
@@ -41,7 +41,7 @@ __device__ void softmaxcrossentropywithlogitsForwardContiguous(const TI* __restr
                                                                tensor_view_1d_t output_tv,
                                                                tensor_view_2d_t backprop_tv)
 {
-    uint64_t gid     = threadIdx.x + blockIdx.x * blockDim.x;
+    uint64_t gid     = blockIdx.x;
     uint64_t lid     = threadIdx.x;
     size_t num_class = input_tv.size[1];
 
@@ -114,11 +114,6 @@ __device__ void softmaxcrossentropywithlogitsForwardContiguous(const TI* __restr
         FLOAT_ACCUM backprop_val   = exp(val - lmax[0]) / lsum[0] - label;
         backprop[i + batch_offset] = CVT_ACCUM2FLOAT(backprop_val);
     }
-
-    if(gid < 10)
-    {
-        printf("gid: %d, lmax: %f, lsum: %f, lloss: %f\n", gid, lmax[0], lsum[0], lloss[0]);
-    }
 }
 
 extern "C" __global__ void
@@ -147,7 +142,7 @@ __device__ void softmaxcrossentropywithlogitsBackwardContiguous(const TI* __rest
                                                                 tensor_view_2d_t input_grad_tv,
                                                                 tensor_view_2d_t target_grad_tv)
 {
-    uint64_t gid     = threadIdx.x + blockIdx.x * blockDim.x;
+    uint64_t gid     = blockIdx.x;
     uint64_t lid     = threadIdx.x;
     size_t num_class = input_tv.size[1];
 

--- a/src/kernels/tensor_view.hpp
+++ b/src/kernels/tensor_view.hpp
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef GUARD_TENSOR_VIEW_H
+#define GUARD_TENSOR_VIEW_H
+
+using tensor_view_1d_t = struct
+{
+    uint64_t stride[1];
+    uint64_t size[1];
+};
+
+using tensor_view_2d_t = struct
+{
+    uint64_t stride[2];
+    uint64_t size[2];
+};
+
+using tensor_view_3d_t = struct
+{
+    uint64_t stride[3];
+    uint64_t size[3];
+};
+
+using tensor_view_4d_t = struct
+{
+    uint64_t stride[4];
+    uint64_t size[4];
+};
+
+using tensor_view_5d_t = struct
+{
+    uint64_t stride[5];
+    uint64_t size[5];
+};
+
+#define TV_IDX(tv, d, n) (tv.stride[d] * (n))
+
+#define TV1D_IDX(tv, n0) (TV_IDX(tv, 0, n0))
+
+#define TV2D_IDX(tv, n0, n1) (TV_IDX(tv, 1, n1) + TV1D_IDX(tv, n0))
+
+#define TV3D_IDX(tv, n0, n1, n2) (TV_IDX(tv, 2, n2) + TV2D_IDX(tv, n0, n1))
+
+#define TV4D_IDX(tv, n0, n1, n2, n3) (TV_IDX(tv, 3, n3) + TV3D_IDX(tv, n0, n1, n2))
+
+#define TV5D_IDX(tv, n0, n1, n2, n3, n4) (TV_IDX(tv, 4, n4) + TV4D_IDX(tv, n0, n1, n2, n3))
+
+#define TV_1D_AT(x, idx) (x[IDX_TO_TV1D_IDX(x##_tv, idx)])
+#define TV_2D_AT(x, n0, n1) (x[TV2D_IDX(x##_tv, n0, n1)])
+#define TV_3D_AT(x, n0, n1, n2) (x[TV3D_IDX(x##_tv, n0, n1, n2)])
+#define TV_4D_AT(x, n0, n1, n2, n3) (x[TV4D_IDX(x##_tv, n0, n1, n2, n3)])
+#define TV_5D_AT(x, n0, n1, n2, n3, n4) (x[TV5D_IDX(x##_tv, n0, n1, n2, n3, n4)])
+
+#define GET_NCDHW(n, c, d, h, w, idx, tv) \
+    {                                     \
+        ulong ncdh = (idx) / tv.size[4];  \
+        w          = (idx) % tv.size[4];  \
+        ulong ncd  = ncdh / tv.size[3];   \
+        h          = ncdh % tv.size[3];   \
+        ulong nc   = ncd / tv.size[2];    \
+        d          = ncd % tv.size[2];    \
+        n          = nc / tv.size[1];     \
+        c          = nc % tv.size[1];     \
+    }
+
+#define GET_NCDH(n, c, d, h, idx, tv)   \
+    {                                   \
+        ulong ncd = (idx) / tv.size[3]; \
+        h         = (idx) % tv.size[3]; \
+        ulong nc  = ncd / tv.size[2];   \
+        d         = ncd % tv.size[2];   \
+        n         = nc / tv.size[1];    \
+        c         = nc % tv.size[1];    \
+    }
+
+#define GET_NCD(n, c, d, idx, tv)      \
+    {                                  \
+        ulong nc = (idx) / tv.size[2]; \
+        d        = (idx) % tv.size[2]; \
+        n        = nc / tv.size[1];    \
+        c        = nc % tv.size[1];    \
+    }
+
+#define GET_ND(n, d, idx, tv)   \
+    {                           \
+        n = (idx) / tv.size[1]; \
+        d = (idx) % tv.size[1]; \
+    }
+
+#endif // GUARD_TENSOR_VIEW_H

--- a/src/softmaxcrossentropywithlogits.cpp
+++ b/src/softmaxcrossentropywithlogits.cpp
@@ -35,28 +35,7 @@
 
 namespace miopen {
 
-size_t GetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(Handle& handle,
-                                                            const TensorDescriptor& inputDesc,
-                                                            const TensorDescriptor& targetDesc,
-                                                            const TensorDescriptor& outputDesc,
-                                                            const TensorDescriptor& backpropDesc)
-{
-    auto ctx           = ExecutionContext{&handle};
-    const auto problem = softmaxcrossentropywithlogits::FwdProblemDescription{
-        inputDesc, targetDesc, outputDesc, backpropDesc};
-
-    const auto algo    = AlgorithmName{"SoftmaxCrossEntropyWithLogitsForward"};
-    const auto solvers = solver::SolverContainer<
-        solver::softmaxcrossentropywithlogits::SoftmaxCrossEntropyWithLogitsForwardContiguous>{};
-
-    auto pair_size_vector = solvers.GetWorkspaceSizes(ctx, problem);
-
-    return pair_size_vector.empty() ? static_cast<size_t>(-1) : pair_size_vector.front().second;
-}
-
 miopenStatus_t SoftmaxCrossEntropyWithLogitsForward(Handle& handle,
-                                                    Data_t workspace,
-                                                    size_t workspaceSizeInBytes,
                                                     const TensorDescriptor& inputDesc,
                                                     ConstData_t input,
                                                     const TensorDescriptor& targetDesc,
@@ -81,9 +60,6 @@ miopenStatus_t SoftmaxCrossEntropyWithLogitsForward(Handle& handle,
         tmp.output   = output;
         tmp.backprop = backprop;
 
-        tmp.workspace            = workspace;
-        tmp.workspaceSizeInBytes = workspaceSizeInBytes;
-
         return tmp;
     }();
     const auto algo    = AlgorithmName{"SoftmaxCrossEntropyWithLogitsForward"};
@@ -95,29 +71,7 @@ miopenStatus_t SoftmaxCrossEntropyWithLogitsForward(Handle& handle,
     return miopenStatusSuccess;
 }
 
-size_t GetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(Handle& handle,
-                                                             const TensorDescriptor& outputGradDesc,
-                                                             const TensorDescriptor& backpropDesc,
-                                                             const TensorDescriptor& inputDesc,
-                                                             const TensorDescriptor& inputGradDesc,
-                                                             const TensorDescriptor& targetGradDesc)
-{
-    auto ctx           = ExecutionContext{&handle};
-    const auto problem = softmaxcrossentropywithlogits::BwdProblemDescription{
-        outputGradDesc, backpropDesc, inputDesc, inputGradDesc, targetGradDesc};
-
-    const auto algo    = AlgorithmName{"SoftmaxCrossEntropyWithLogitsBackward"};
-    const auto solvers = solver::SolverContainer<
-        solver::softmaxcrossentropywithlogits::SoftmaxCrossEntropyWithLogitsBackwardContiguous>{};
-
-    auto pair_size_vector = solvers.GetWorkspaceSizes(ctx, problem);
-
-    return pair_size_vector.empty() ? static_cast<size_t>(-1) : pair_size_vector.front().second;
-}
-
 miopenStatus_t SoftmaxCrossEntropyWithLogitsBackward(Handle& handle,
-                                                     Data_t workspace,
-                                                     size_t workspaceSizeInBytes,
                                                      const TensorDescriptor& outputGradDesc,
                                                      ConstData_t output_grad,
                                                      const TensorDescriptor& backpropDesc,
@@ -145,9 +99,6 @@ miopenStatus_t SoftmaxCrossEntropyWithLogitsBackward(Handle& handle,
         tmp.input       = input;
         tmp.input_grad  = input_grad;
         tmp.target_grad = target_grad;
-
-        tmp.workspace            = workspace;
-        tmp.workspaceSizeInBytes = workspaceSizeInBytes;
 
         return tmp;
     }();

--- a/src/softmaxcrossentropywithlogits.cpp
+++ b/src/softmaxcrossentropywithlogits.cpp
@@ -1,0 +1,299 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "miopen/miopen.h"
+#include <miopen/softmaxcrossentropywithlogits.hpp>
+#include <miopen/kernel_cache.hpp>
+#include <miopen/float_equal.hpp>
+#include <miopen/tensor.hpp>
+#include <miopen/softmaxcrossentropywithlogits/invoke_params.hpp>
+#include <miopen/softmaxcrossentropywithlogits/solvers.hpp>
+#include <miopen/find_solution.hpp>
+
+namespace miopen {
+
+size_t GetCosineEmbeddingLossUnreducedForwardWorkspaceSize(Handle& handle,
+                                                           const TensorDescriptor input1Desc,
+                                                           const TensorDescriptor input2Desc,
+                                                           const TensorDescriptor targetDesc,
+                                                           const TensorDescriptor outputDesc,
+                                                           const float margin)
+{
+    auto ctx           = ExecutionContext{&handle};
+    const auto problem = cosineembeddingloss::FwdUnreducedProblemDescription{
+        input1Desc, input2Desc, targetDesc, outputDesc, margin};
+
+    const auto algo    = AlgorithmName{"CosineEmbeddingLossUnreducedForward"};
+    const auto solvers = solver::SolverContainer<
+        solver::cosineembeddingloss::CosineEmbeddingLossUnreducedForward2d,
+        solver::cosineembeddingloss::CosineEmbeddingLossUnreducedForward2dNonSum>{};
+
+    auto pair_size_vector = solvers.GetWorkspaceSizes(ctx, problem);
+
+    return pair_size_vector.empty() ? static_cast<size_t>(-1) : pair_size_vector.front().second;
+}
+
+size_t GetCosineEmbeddingLossReducedForwardWorkspaceSize(Handle& handle,
+                                                         const TensorDescriptor input1Desc,
+                                                         const TensorDescriptor input2Desc,
+                                                         const TensorDescriptor targetDesc,
+                                                         const TensorDescriptor outputDesc,
+                                                         const float margin)
+{
+    auto ctx           = ExecutionContext{&handle};
+    const auto problem = cosineembeddingloss::FwdReducedProblemDescription{
+        input1Desc, input2Desc, targetDesc, outputDesc, margin};
+
+    const auto algo    = AlgorithmName{"CosineEmbeddingLossReducedForward"};
+    const auto solvers = solver::SolverContainer<
+        solver::cosineembeddingloss::CosineEmbeddingLossReducedForward2d,
+        solver::cosineembeddingloss::CosineEmbeddingLossReducedForward2dNonSum>{};
+
+    auto pair_size_vector = solvers.GetWorkspaceSizes(ctx, problem);
+
+    return pair_size_vector.empty() ? static_cast<size_t>(-1) : pair_size_vector.front().second;
+}
+
+miopenStatus_t CosineEmbeddingLossUnreducedForward(Handle& handle,
+                                                   Data_t workspace,
+                                                   size_t workspaceSizeInBytes,
+                                                   const TensorDescriptor& input1Desc,
+                                                   ConstData_t input1,
+                                                   const TensorDescriptor& input2Desc,
+                                                   ConstData_t input2,
+                                                   const TensorDescriptor& targetDesc,
+                                                   ConstData_t target,
+                                                   const TensorDescriptor& outputDesc,
+                                                   Data_t output,
+                                                   const float margin)
+{
+    const auto problem = cosineembeddingloss::FwdUnreducedProblemDescription{
+        input1Desc, input2Desc, targetDesc, outputDesc, margin};
+
+    const auto invoke_params = [&]() {
+        auto tmp       = cosineembeddingloss::FwdInvokeParams{};
+        tmp.input1Desc = &input1Desc;
+        tmp.input2Desc = &input2Desc;
+        tmp.targetDesc = &targetDesc;
+        tmp.outputDesc = &outputDesc;
+
+        tmp.input1 = input1;
+        tmp.input2 = input2;
+        tmp.target = target;
+        tmp.output = output;
+
+        tmp.workspace            = workspace;
+        tmp.workspaceSizeInBytes = workspaceSizeInBytes;
+
+        tmp.margin = margin;
+
+        return tmp;
+    }();
+    const auto algo    = AlgorithmName{"CosineEmbeddingLossUnreducedForward"};
+    const auto solvers = solver::SolverContainer<
+        solver::cosineembeddingloss::CosineEmbeddingLossUnreducedForward2d,
+        solver::cosineembeddingloss::CosineEmbeddingLossUnreducedForward2dNonSum>{};
+
+    solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
+
+    return miopenStatusSuccess;
+}
+
+miopenStatus_t CosineEmbeddingLossReducedForward(Handle& handle,
+                                                 Data_t workspace,
+                                                 size_t workspaceSizeInBytes,
+                                                 const TensorDescriptor& input1Desc,
+                                                 ConstData_t input1,
+                                                 const TensorDescriptor& input2Desc,
+                                                 ConstData_t input2,
+                                                 const TensorDescriptor& targetDesc,
+                                                 ConstData_t target,
+                                                 const TensorDescriptor& outputDesc,
+                                                 Data_t output,
+                                                 const float margin,
+                                                 const miopenLossReductionMode_t reduction)
+{
+    const auto problem = cosineembeddingloss::FwdReducedProblemDescription{
+        input1Desc, input2Desc, targetDesc, outputDesc, margin};
+
+    const auto invoke_params = [&]() {
+        auto tmp       = cosineembeddingloss::FwdInvokeParams{};
+        tmp.input1Desc = &input1Desc;
+        tmp.input2Desc = &input2Desc;
+        tmp.targetDesc = &targetDesc;
+        tmp.outputDesc = &outputDesc;
+
+        tmp.input1               = input1;
+        tmp.input2               = input2;
+        tmp.target               = target;
+        tmp.output               = output;
+        tmp.workspace            = workspace;
+        tmp.workspaceSizeInBytes = workspaceSizeInBytes;
+        tmp.margin               = margin;
+        tmp.reduction            = reduction;
+        return tmp;
+    }();
+
+    const auto algo    = AlgorithmName{"CosineEmbeddingLossReducedForward"};
+    const auto solvers = solver::SolverContainer<
+        solver::cosineembeddingloss::CosineEmbeddingLossReducedForward2d,
+        solver::cosineembeddingloss::CosineEmbeddingLossReducedForward2dNonSum>{};
+
+    solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
+
+    return miopenStatusSuccess;
+}
+
+size_t GetCosineEmbeddingLossBackwardWorkspaceSize(Handle& handle,
+                                                   const TensorDescriptor input1Desc,
+                                                   const TensorDescriptor input2Desc,
+                                                   const TensorDescriptor targetDesc,
+                                                   const TensorDescriptor outputGradDesc,
+                                                   const TensorDescriptor input1GradDesc,
+                                                   const TensorDescriptor input2GradDesc,
+                                                   const float margin)
+{
+    auto ctx           = ExecutionContext{&handle};
+    const auto problem = cosineembeddingloss::BwdUnreducedProblemDescription{
+        input1Desc, input2Desc, targetDesc, outputGradDesc, input1GradDesc, input2GradDesc, margin};
+
+    const auto algo    = AlgorithmName{"CosineEmbeddingLossBackward"};
+    const auto solvers = solver::SolverContainer<
+        solver::cosineembeddingloss::CosineEmbeddingLossUnreducedBackward2d,
+        solver::cosineembeddingloss::CosineEmbeddingLossUnreducedBackward2dNonSum>{};
+
+    auto pair_size_vector = solvers.GetWorkspaceSizes(ctx, problem);
+
+    return pair_size_vector.empty() ? static_cast<size_t>(-1) : pair_size_vector.front().second;
+}
+
+miopenStatus_t CosineEmbeddingLossUnreducedBackward(Handle& handle,
+                                                    Data_t workspace,
+                                                    size_t workspaceSizeInBytes,
+                                                    const TensorDescriptor& input1Desc,
+                                                    ConstData_t input1,
+                                                    const TensorDescriptor& input2Desc,
+                                                    ConstData_t input2,
+                                                    const TensorDescriptor& targetDesc,
+                                                    ConstData_t target,
+                                                    const TensorDescriptor& outputGradDesc,
+                                                    ConstData_t output_grad,
+                                                    const TensorDescriptor& input1GradDesc,
+                                                    Data_t input1_grad,
+                                                    const TensorDescriptor& input2GradDesc,
+                                                    Data_t input2_grad,
+                                                    const float margin)
+{
+    const auto problem = cosineembeddingloss::BwdUnreducedProblemDescription{
+        input1Desc, input2Desc, targetDesc, outputGradDesc, input1GradDesc, input2GradDesc, margin};
+
+    const auto invoke_params = [&]() {
+        auto tmp           = cosineembeddingloss::BwdInvokeParams{};
+        tmp.input1Desc     = &input1Desc;
+        tmp.input2Desc     = &input2Desc;
+        tmp.targetDesc     = &targetDesc;
+        tmp.outputGradDesc = &outputGradDesc;
+        tmp.input1GradDesc = &input1GradDesc;
+        tmp.input2GradDesc = &input2GradDesc;
+
+        tmp.input1      = input1;
+        tmp.input2      = input2;
+        tmp.target      = target;
+        tmp.output_grad = output_grad;
+        tmp.input1_grad = input1_grad;
+        tmp.input2_grad = input2_grad;
+
+        tmp.workspace            = workspace;
+        tmp.workspaceSizeInBytes = workspaceSizeInBytes;
+        tmp.margin               = margin;
+
+        return tmp;
+    }();
+    const auto algo    = AlgorithmName{"CosineEmbeddingLossUnreducedBackward"};
+    const auto solvers = solver::SolverContainer<
+        solver::cosineembeddingloss::CosineEmbeddingLossUnreducedBackward2d,
+        solver::cosineembeddingloss::CosineEmbeddingLossUnreducedBackward2dNonSum>{};
+
+    solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
+
+    return miopenStatusSuccess;
+}
+
+miopenStatus_t CosineEmbeddingLossReducedBackward(Handle& handle,
+                                                  Data_t workspace,
+                                                  size_t workspaceSizeInBytes,
+                                                  const TensorDescriptor& input1Desc,
+                                                  ConstData_t input1,
+                                                  const TensorDescriptor& input2Desc,
+                                                  ConstData_t input2,
+                                                  const TensorDescriptor& targetDesc,
+                                                  ConstData_t target,
+                                                  const TensorDescriptor& outputGradDesc,
+                                                  ConstData_t output_grad,
+                                                  const TensorDescriptor& input1GradDesc,
+                                                  Data_t input1_grad,
+                                                  const TensorDescriptor& input2GradDesc,
+                                                  Data_t input2_grad,
+                                                  const float margin,
+                                                  const miopenLossReductionMode_t reduction)
+{
+    const auto problem = cosineembeddingloss::BwdReducedProblemDescription{
+        input1Desc, input2Desc, targetDesc, outputGradDesc, input1GradDesc, input2GradDesc, margin};
+
+    const auto invoke_params = [&]() {
+        auto tmp           = cosineembeddingloss::BwdInvokeParams{};
+        tmp.input1Desc     = &input1Desc;
+        tmp.input2Desc     = &input2Desc;
+        tmp.targetDesc     = &targetDesc;
+        tmp.outputGradDesc = &outputGradDesc;
+        tmp.input1GradDesc = &input1GradDesc;
+        tmp.input2GradDesc = &input2GradDesc;
+
+        tmp.input1      = input1;
+        tmp.input2      = input2;
+        tmp.target      = target;
+        tmp.output_grad = output_grad;
+        tmp.input1_grad = input1_grad;
+        tmp.input2_grad = input2_grad;
+
+        tmp.workspace            = workspace;
+        tmp.workspaceSizeInBytes = workspaceSizeInBytes;
+        tmp.margin               = margin;
+        tmp.reduction            = reduction;
+
+        return tmp;
+    }();
+    const auto algo    = AlgorithmName{"CosineEmbeddingLossReducedBackward"};
+    const auto solvers = solver::SolverContainer<
+        solver::cosineembeddingloss::CosineEmbeddingLossReducedBackward2d,
+        solver::cosineembeddingloss::CosineEmbeddingLossReducedBackward2dNonSum>{};
+
+    solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
+
+    return miopenStatusSuccess;
+}
+
+} // namespace miopen

--- a/src/softmaxcrossentropywithlogits/problem_description.cpp
+++ b/src/softmaxcrossentropywithlogits/problem_description.cpp
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <cstddef>
+#include <miopen/softmaxcrossentropywithlogits/problem_description.hpp>
+#include <miopen/names.hpp>
+
+#include <sstream>
+
+namespace miopen {
+
+namespace softmaxcrossentropywithlogits {
+
+inline std::ostream& operator<<(std::ostream& os, const std::vector<size_t>& v)
+{
+    os << '{';
+    for(int i = 0; i < v.size(); ++i)
+    {
+        if(i != 0)
+            os << ',';
+        os << v[i];
+    }
+    os << '}';
+    return os;
+}
+
+NetworkConfig FwdProblemDescription::MakeNetworkConfig() const
+{
+    auto input_dims  = inputDesc.GetLengths();
+    auto input_dtype = inputDesc.GetType();
+    auto Si          = inputDesc.GetStrides();
+    auto St          = targetDesc.GetStrides();
+    auto So          = outputDesc.GetStrides();
+    auto Sb          = backpropDesc.GetStrides();
+
+    std::ostringstream ss;
+    ss << "softmaxcrossentropywithlogits";
+    ss << "is_fwd" << true;
+    ss << "input_dtype" << input_dtype;
+    ss << "input_dims" << input_dims;
+    ss << "input1_stride" << Si;
+    ss << "target_stride" << St;
+    ss << "output_stride" << So;
+    ss << "backprop_stride" << Sb;
+
+    return NetworkConfig{ss.str()};
+}
+
+NetworkConfig BwdProblemDescription::MakeNetworkConfig() const
+{
+    auto input_dims  = inputDesc.GetLengths();
+    auto input_dtype = inputDesc.GetType();
+    auto Sdo         = outputGradDesc.GetStrides();
+    auto Sb          = backpropDesc.GetStrides();
+    auto Si          = inputDesc.GetStrides();
+    auto Sdi         = inputGradDesc.GetStrides();
+    auto Sdt         = targetGradDesc.GetStrides();
+
+    std::ostringstream ss;
+    ss << "softmaxcrossentropywithlogits";
+    ss << "is_fwd" << false;
+    ss << "input_dtype" << input_dtype;
+    ss << "input_dims" << input_dims;
+    ss << "output_grad_stride" << Sdo;
+    ss << "backprop_stride" << Sb;
+    ss << "input_stride" << Si;
+    ss << "input_grad_stride" << Sdi;
+    ss << "target_grad_stride" << Sdt;
+
+    return NetworkConfig{ss.str()};
+}
+
+} // namespace softmaxcrossentropywithlogits
+
+} // namespace miopen

--- a/src/softmaxcrossentropywithlogits_api.cpp
+++ b/src/softmaxcrossentropywithlogits_api.cpp
@@ -74,31 +74,8 @@ static void LogCmdSoftmaxCrossEntropyWithLogits(const miopenTensorDescriptor_t i
     }
 }
 
-extern "C" miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(
-    miopenHandle_t handle,
-    const miopenTensorDescriptor_t inputDesc,
-    const miopenTensorDescriptor_t targetDesc,
-    const miopenTensorDescriptor_t outputDesc,
-    const miopenTensorDescriptor_t backpropDesc,
-    size_t* sizeInBytes)
-{
-
-    MIOPEN_LOG_FUNCTION(handle, inputDesc, targetDesc, outputDesc, backpropDesc, sizeInBytes);
-
-    return miopen::try_([&] {
-        miopen::deref(sizeInBytes) = miopen::GetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(
-            miopen::deref(handle),
-            miopen::deref(inputDesc),
-            miopen::deref(targetDesc),
-            miopen::deref(outputDesc),
-            miopen::deref(backpropDesc));
-    });
-}
-
 extern "C" miopenStatus_t
 miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
-                                           void* workspace,
-                                           size_t workspaceSizeInBytes,
                                            const miopenTensorDescriptor_t inputDesc,
                                            const void* input,
                                            const miopenTensorDescriptor_t targetDesc,
@@ -108,24 +85,13 @@ miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
                                            const miopenTensorDescriptor_t backpropDesc,
                                            void* backprop)
 {
-    MIOPEN_LOG_FUNCTION(handle,
-                        workspace,
-                        workspaceSizeInBytes,
-                        inputDesc,
-                        input,
-                        targetDesc,
-                        target,
-                        outputDesc,
-                        output,
-                        backpropDesc,
-                        backprop);
+    MIOPEN_LOG_FUNCTION(
+        handle, inputDesc, input, targetDesc, target, outputDesc, output, backpropDesc, backprop);
 
     LogCmdSoftmaxCrossEntropyWithLogits(inputDesc, true);
 
     return miopen::try_([&] {
         miopen::SoftmaxCrossEntropyWithLogitsForward(miopen::deref(handle),
-                                                     DataCast(workspace),
-                                                     workspaceSizeInBytes,
                                                      miopen::deref(inputDesc),
                                                      DataCast(input),
                                                      miopen::deref(targetDesc),
@@ -137,39 +103,8 @@ miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
     });
 }
 
-extern "C" miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(
-    miopenHandle_t handle,
-    const miopenTensorDescriptor_t outputGradDesc,
-    const miopenTensorDescriptor_t backpropDesc,
-    const miopenTensorDescriptor_t inputDesc,
-    const miopenTensorDescriptor_t inputGradDesc,
-    const miopenTensorDescriptor_t targetGradDesc,
-    size_t* sizeInBytes)
-{
-
-    MIOPEN_LOG_FUNCTION(handle,
-                        outputGradDesc,
-                        backpropDesc,
-                        inputDesc,
-                        inputGradDesc,
-                        targetGradDesc,
-                        sizeInBytes);
-
-    return miopen::try_([&] {
-        miopen::deref(sizeInBytes) = miopen::GetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(
-            miopen::deref(handle),
-            miopen::deref(outputGradDesc),
-            miopen::deref(backpropDesc),
-            miopen::deref(inputDesc),
-            miopen::deref(inputGradDesc),
-            miopen::deref(targetGradDesc));
-    });
-}
-
 extern "C" miopenStatus_t
 miopenSoftmaxCrossEntropyWithLogitsBackward(miopenHandle_t handle,
-                                            void* workspace,
-                                            size_t workspaceSizeInBytes,
                                             const miopenTensorDescriptor_t outputGradDesc,
                                             const void* output_grad,
                                             const miopenTensorDescriptor_t backpropDesc,
@@ -182,8 +117,6 @@ miopenSoftmaxCrossEntropyWithLogitsBackward(miopenHandle_t handle,
                                             void* target_grad)
 {
     MIOPEN_LOG_FUNCTION(handle,
-                        workspace,
-                        workspaceSizeInBytes,
                         outputGradDesc,
                         output_grad,
                         backpropDesc,
@@ -199,8 +132,6 @@ miopenSoftmaxCrossEntropyWithLogitsBackward(miopenHandle_t handle,
 
     return miopen::try_([&] {
         miopen::SoftmaxCrossEntropyWithLogitsBackward(miopen::deref(handle),
-                                                      DataCast(workspace),
-                                                      workspaceSizeInBytes,
                                                       miopen::deref(outputGradDesc),
                                                       DataCast(output_grad),
                                                       miopen::deref(backpropDesc),

--- a/src/softmaxcrossentropywithlogits_api.cpp
+++ b/src/softmaxcrossentropywithlogits_api.cpp
@@ -45,8 +45,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<size_t>& v)
 }
 
 static void LogCmdSoftmaxCrossEntropyWithLogits(const miopenTensorDescriptor_t inputDesc,
-                                                bool is_fwd,
-                                                const miopenLossContiguousMode_t is_contiguous)
+                                                bool is_fwd)
 {
     if(miopen::IsLoggingCmd())
     {
@@ -65,12 +64,11 @@ static void LogCmdSoftmaxCrossEntropyWithLogits(const miopenTensorDescriptor_t i
             ss << "softmaxcrossentropywithlogitsbfp16";
         }
 
-        MIOPEN_LOG_FUNCTION(inputDesc, is_fwd, is_contiguous);
+        MIOPEN_LOG_FUNCTION(inputDesc, is_fwd);
         ss << " -D " << miopen::deref(inputDesc).GetLengths();
         ss << " -Si " << miopen::deref(inputDesc).GetStrides();
 
         ss << " -F " << ((is_fwd) ? "1" : "2");
-        ss << " -C " << is_contiguous;
 
         MIOPEN_LOG_DRIVER_CMD(ss.str());
     }
@@ -82,12 +80,10 @@ extern "C" miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsForwardWorkspace
     const miopenTensorDescriptor_t targetDesc,
     const miopenTensorDescriptor_t outputDesc,
     const miopenTensorDescriptor_t backpropDesc,
-    size_t* sizeInBytes,
-    const miopenLossContiguousMode_t is_contiguous)
+    size_t* sizeInBytes)
 {
 
-    MIOPEN_LOG_FUNCTION(
-        handle, inputDesc, targetDesc, outputDesc, backpropDesc, sizeInBytes, is_contiguous);
+    MIOPEN_LOG_FUNCTION(handle, inputDesc, targetDesc, outputDesc, backpropDesc, sizeInBytes);
 
     return miopen::try_([&] {
         miopen::deref(sizeInBytes) = miopen::GetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(
@@ -95,8 +91,7 @@ extern "C" miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsForwardWorkspace
             miopen::deref(inputDesc),
             miopen::deref(targetDesc),
             miopen::deref(outputDesc),
-            miopen::deref(backpropDesc),
-            is_contiguous);
+            miopen::deref(backpropDesc));
     });
 }
 
@@ -111,8 +106,7 @@ miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
                                            const miopenTensorDescriptor_t outputDesc,
                                            void* output,
                                            const miopenTensorDescriptor_t backpropDesc,
-                                           void* backprop,
-                                           const miopenLossContiguousMode_t is_contiguous)
+                                           void* backprop)
 {
     MIOPEN_LOG_FUNCTION(handle,
                         workspace,
@@ -124,10 +118,9 @@ miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
                         outputDesc,
                         output,
                         backpropDesc,
-                        backprop,
-                        is_contiguous);
+                        backprop);
 
-    LogCmdSoftmaxCrossEntropyWithLogits(inputDesc, true, is_contiguous);
+    LogCmdSoftmaxCrossEntropyWithLogits(inputDesc, true);
 
     return miopen::try_([&] {
         miopen::SoftmaxCrossEntropyWithLogitsForward(miopen::deref(handle),
@@ -140,8 +133,7 @@ miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
                                                      miopen::deref(outputDesc),
                                                      DataCast(output),
                                                      miopen::deref(backpropDesc),
-                                                     DataCast(backprop),
-                                                     is_contiguous);
+                                                     DataCast(backprop));
     });
 }
 
@@ -152,8 +144,7 @@ extern "C" miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsBackwardWorkspac
     const miopenTensorDescriptor_t inputDesc,
     const miopenTensorDescriptor_t inputGradDesc,
     const miopenTensorDescriptor_t targetGradDesc,
-    size_t* sizeInBytes,
-    const miopenLossContiguousMode_t is_contiguous)
+    size_t* sizeInBytes)
 {
 
     MIOPEN_LOG_FUNCTION(handle,
@@ -162,8 +153,7 @@ extern "C" miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsBackwardWorkspac
                         inputDesc,
                         inputGradDesc,
                         targetGradDesc,
-                        sizeInBytes,
-                        is_contiguous);
+                        sizeInBytes);
 
     return miopen::try_([&] {
         miopen::deref(sizeInBytes) = miopen::GetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(
@@ -172,8 +162,7 @@ extern "C" miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsBackwardWorkspac
             miopen::deref(backpropDesc),
             miopen::deref(inputDesc),
             miopen::deref(inputGradDesc),
-            miopen::deref(targetGradDesc),
-            is_contiguous);
+            miopen::deref(targetGradDesc));
     });
 }
 
@@ -190,8 +179,7 @@ miopenSoftmaxCrossEntropyWithLogitsBackward(miopenHandle_t handle,
                                             const miopenTensorDescriptor_t inputGradDesc,
                                             void* input_grad,
                                             const miopenTensorDescriptor_t targetGradDesc,
-                                            void* target_grad,
-                                            const miopenLossContiguousMode_t is_contiguous)
+                                            void* target_grad)
 {
     MIOPEN_LOG_FUNCTION(handle,
                         workspace,
@@ -205,10 +193,9 @@ miopenSoftmaxCrossEntropyWithLogitsBackward(miopenHandle_t handle,
                         inputGradDesc,
                         input_grad,
                         targetGradDesc,
-                        target_grad,
-                        is_contiguous);
+                        target_grad);
 
-    LogCmdSoftmaxCrossEntropyWithLogits(inputDesc, false, is_contiguous);
+    LogCmdSoftmaxCrossEntropyWithLogits(inputDesc, false);
 
     return miopen::try_([&] {
         miopen::SoftmaxCrossEntropyWithLogitsBackward(miopen::deref(handle),
@@ -223,7 +210,6 @@ miopenSoftmaxCrossEntropyWithLogitsBackward(miopenHandle_t handle,
                                                       miopen::deref(inputGradDesc),
                                                       DataCast(input_grad),
                                                       miopen::deref(targetGradDesc),
-                                                      DataCast(target_grad),
-                                                      is_contiguous);
+                                                      DataCast(target_grad));
     });
 }

--- a/src/softmaxcrossentropywithlogits_api.cpp
+++ b/src/softmaxcrossentropywithlogits_api.cpp
@@ -1,0 +1,229 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "miopen/miopen.h"
+#include <miopen/softmaxcrossentropywithlogits.hpp>
+#include <miopen/errors.hpp>
+#include <miopen/handle.hpp>
+#include <miopen/logger.hpp>
+#include <miopen/tensor_ops.hpp>
+
+inline std::ostream& operator<<(std::ostream& os, const std::vector<size_t>& v)
+{
+    os << '{';
+    for(int i = 0; i < v.size(); ++i)
+    {
+        if(i != 0)
+            os << ',';
+        os << v[i];
+    }
+    os << '}';
+    return os;
+}
+
+static void LogCmdSoftmaxCrossEntropyWithLogits(const miopenTensorDescriptor_t inputDesc,
+                                                bool is_fwd,
+                                                const miopenLossContiguousMode_t is_contiguous)
+{
+    if(miopen::IsLoggingCmd())
+    {
+        std::stringstream ss;
+        auto dtype = miopen::deref(inputDesc).GetType();
+        if(dtype == miopenHalf)
+        {
+            ss << "softmaxcrossentropywithlogitsfp16";
+        }
+        else if(dtype == miopenFloat)
+        {
+            ss << "softmaxcrossentropywithlogits";
+        }
+        else if(dtype == miopenBFloat16)
+        {
+            ss << "softmaxcrossentropywithlogitsbfp16";
+        }
+
+        MIOPEN_LOG_FUNCTION(inputDesc, is_fwd, is_contiguous);
+        ss << " -D " << miopen::deref(inputDesc).GetLengths();
+        ss << " -Si " << miopen::deref(inputDesc).GetStrides();
+
+        ss << " -F " << ((is_fwd) ? "1" : "2");
+        ss << " -C " << is_contiguous;
+
+        MIOPEN_LOG_DRIVER_CMD(ss.str());
+    }
+}
+
+extern "C" miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(
+    miopenHandle_t handle,
+    const miopenTensorDescriptor_t inputDesc,
+    const miopenTensorDescriptor_t targetDesc,
+    const miopenTensorDescriptor_t outputDesc,
+    const miopenTensorDescriptor_t backpropDesc,
+    size_t* sizeInBytes,
+    const miopenLossContiguousMode_t is_contiguous)
+{
+
+    MIOPEN_LOG_FUNCTION(
+        handle, inputDesc, targetDesc, outputDesc, backpropDesc, sizeInBytes, is_contiguous);
+
+    return miopen::try_([&] {
+        miopen::deref(sizeInBytes) = miopen::GetSoftmaxCrossEntropyWithLogitsForwardWorkspaceSize(
+            miopen::deref(handle),
+            miopen::deref(inputDesc),
+            miopen::deref(targetDesc),
+            miopen::deref(outputDesc),
+            miopen::deref(backpropDesc),
+            is_contiguous);
+    });
+}
+
+extern "C" miopenStatus_t
+miopenSoftmaxCrossEntropyWithLogitsForward(miopenHandle_t handle,
+                                           void* workspace,
+                                           size_t workspaceSizeInBytes,
+                                           const miopenTensorDescriptor_t inputDesc,
+                                           const void* input,
+                                           const miopenTensorDescriptor_t targetDesc,
+                                           const void* target,
+                                           const miopenTensorDescriptor_t outputDesc,
+                                           void* output,
+                                           const miopenTensorDescriptor_t backpropDesc,
+                                           void* backprop,
+                                           const miopenLossContiguousMode_t is_contiguous)
+{
+    MIOPEN_LOG_FUNCTION(handle,
+                        workspace,
+                        workspaceSizeInBytes,
+                        inputDesc,
+                        input,
+                        targetDesc,
+                        target,
+                        outputDesc,
+                        output,
+                        backpropDesc,
+                        backprop,
+                        is_contiguous);
+
+    LogCmdSoftmaxCrossEntropyWithLogits(inputDesc, true, is_contiguous);
+
+    return miopen::try_([&] {
+        miopen::SoftmaxCrossEntropyWithLogitsForward(miopen::deref(handle),
+                                                     DataCast(workspace),
+                                                     workspaceSizeInBytes,
+                                                     miopen::deref(inputDesc),
+                                                     DataCast(input),
+                                                     miopen::deref(targetDesc),
+                                                     DataCast(target),
+                                                     miopen::deref(outputDesc),
+                                                     DataCast(output),
+                                                     miopen::deref(backpropDesc),
+                                                     DataCast(backprop),
+                                                     is_contiguous);
+    });
+}
+
+extern "C" miopenStatus_t miopenGetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(
+    miopenHandle_t handle,
+    const miopenTensorDescriptor_t outputGradDesc,
+    const miopenTensorDescriptor_t backpropDesc,
+    const miopenTensorDescriptor_t inputDesc,
+    const miopenTensorDescriptor_t inputGradDesc,
+    const miopenTensorDescriptor_t targetGradDesc,
+    size_t* sizeInBytes,
+    const miopenLossContiguousMode_t is_contiguous)
+{
+
+    MIOPEN_LOG_FUNCTION(handle,
+                        outputGradDesc,
+                        backpropDesc,
+                        inputDesc,
+                        inputGradDesc,
+                        targetGradDesc,
+                        sizeInBytes,
+                        is_contiguous);
+
+    return miopen::try_([&] {
+        miopen::deref(sizeInBytes) = miopen::GetSoftmaxCrossEntropyWithLogitsBackwardWorkspaceSize(
+            miopen::deref(handle),
+            miopen::deref(outputGradDesc),
+            miopen::deref(backpropDesc),
+            miopen::deref(inputDesc),
+            miopen::deref(inputGradDesc),
+            miopen::deref(targetGradDesc),
+            is_contiguous);
+    });
+}
+
+extern "C" miopenStatus_t
+miopenSoftmaxCrossEntropyWithLogitsBackward(miopenHandle_t handle,
+                                            void* workspace,
+                                            size_t workspaceSizeInBytes,
+                                            const miopenTensorDescriptor_t outputGradDesc,
+                                            const void* output_grad,
+                                            const miopenTensorDescriptor_t backpropDesc,
+                                            const void* backprop,
+                                            const miopenTensorDescriptor_t inputDesc,
+                                            const void* input,
+                                            const miopenTensorDescriptor_t inputGradDesc,
+                                            void* input_grad,
+                                            const miopenTensorDescriptor_t targetGradDesc,
+                                            void* target_grad,
+                                            const miopenLossContiguousMode_t is_contiguous)
+{
+    MIOPEN_LOG_FUNCTION(handle,
+                        workspace,
+                        workspaceSizeInBytes,
+                        outputGradDesc,
+                        output_grad,
+                        backpropDesc,
+                        backprop,
+                        inputDesc,
+                        input,
+                        inputGradDesc,
+                        input_grad,
+                        targetGradDesc,
+                        target_grad,
+                        is_contiguous);
+
+    LogCmdSoftmaxCrossEntropyWithLogits(inputDesc, false, is_contiguous);
+
+    return miopen::try_([&] {
+        miopen::SoftmaxCrossEntropyWithLogitsBackward(miopen::deref(handle),
+                                                      DataCast(workspace),
+                                                      workspaceSizeInBytes,
+                                                      miopen::deref(outputGradDesc),
+                                                      DataCast(output_grad),
+                                                      miopen::deref(backpropDesc),
+                                                      DataCast(backprop),
+                                                      miopen::deref(inputDesc),
+                                                      DataCast(input),
+                                                      miopen::deref(inputGradDesc),
+                                                      DataCast(input_grad),
+                                                      miopen::deref(targetGradDesc),
+                                                      DataCast(target_grad),
+                                                      is_contiguous);
+    });
+}

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -35,6 +35,7 @@
 #include <miopen/reduce/solvers.hpp>
 #include <miopen/mha/solvers.hpp>
 #include <miopen/softmax/solvers.hpp>
+#include <miopen/softmaxcrossentropywithlogits/solvers.hpp>
 
 #include <miopen/conv_algo_name.hpp>
 #include <miopen/db.hpp>
@@ -649,6 +650,16 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
     Register(registry, ++id, Primitive::Softmax, softmax::Softmax{}.SolverDbId());
     Register(registry, ++id, Primitive::Softmax, softmax::AttnSoftmax{}.SolverDbId());
 
+    Register(registry,
+             ++id,
+             Primitive::SoftmaxCrossEntropyWithLogits,
+             softmaxcrossentropywithlogits::SoftmaxCrossEntropyWithLogitForwardContiguous{}
+                 .SolverDbId());
+    Register(registry,
+             ++id,
+             Primitive::SoftmaxCrossEntropyWithLogits,
+             softmaxcrossentropywithlogits::SoftmaxCrossEntropyWithLogitBackwardContiguous{}
+                 .SolverDbId());
     // IMPORTANT: New solvers should be added to the end of the function!
 }
 

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -653,12 +653,12 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
     Register(registry,
              ++id,
              Primitive::SoftmaxCrossEntropyWithLogits,
-             softmaxcrossentropywithlogits::SoftmaxCrossEntropyWithLogitForwardContiguous{}
+             softmaxcrossentropywithlogits::SoftmaxCrossEntropyWithLogitsForwardContiguous{}
                  .SolverDbId());
     Register(registry,
              ++id,
              Primitive::SoftmaxCrossEntropyWithLogits,
-             softmaxcrossentropywithlogits::SoftmaxCrossEntropyWithLogitBackwardContiguous{}
+             softmaxcrossentropywithlogits::SoftmaxCrossEntropyWithLogitsBackwardContiguous{}
                  .SolverDbId());
     // IMPORTANT: New solvers should be added to the end of the function!
 }

--- a/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
+++ b/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
@@ -96,7 +96,7 @@ ConvSolution SoftmaxCrossEntropyWithLogitsBackwardContiguous::GetSolution(
             decltype(auto) params =
                 raw_params.CastTo<miopen::softmaxcrossentropywithlogits::BwdInvokeParams>();
 
-            auto input_tv       = get_inner_expanded_tv_2d(deref(params.inputDesc));
+            auto input_tv    = get_inner_expanded_tv_2d(deref(params.inputDesc));
             size_t num_class = input_tv.size[1];
 
             kernel(params.output_grad,

--- a/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
+++ b/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "miopen/conv_solution.hpp"
+#include "miopen/execution_context.hpp"
+#include "miopen/invoke_params.hpp"
+#include <miopen/softmaxcrossentropywithlogits/solvers.hpp>
+
+#include <miopen/softmaxcrossentropywithlogits/invoke_params.hpp>
+#include <miopen/datatype.hpp>
+#include <miopen/softmaxcrossentropywithlogits.hpp>
+#include <miopen/target_properties.hpp>
+#include <miopen/tensor_view.hpp>
+
+#define LOCAL_SIZE_CON_BWD 1024
+
+namespace miopen {
+
+namespace solver {
+
+namespace softmaxcrossentropywithlogits {
+
+bool SoftmaxCrossEntropyWithLogitsBackwardContiguous::IsApplicable(
+    const ExecutionContext&,
+    const miopen::softmaxcrossentropywithlogits::BwdProblemDescription& problem) const
+{
+    if(!problem.IsAllContiguous())
+        return false;
+
+    return true;
+}
+
+ConvSolution SoftmaxCrossEntropyWithLogitsBackwardContiguous::GetSolution(
+    const ExecutionContext& context,
+    const miopen::softmaxcrossentropywithlogits::BwdProblemDescription& problem) const
+{
+    std::ignore = context;
+
+    auto result       = ConvSolution{miopenStatusSuccess};
+    auto input_dtype  = miopen::GetDataType(problem.GetInputDesc().GetType());
+    auto output_dtype = miopen::GetDataType(problem.GetInputGradDesc().GetType());
+
+    {
+        auto dtype     = problem.GetInputGradDesc().GetType();
+        size_t N_total = problem.GetInputTotal();
+
+        auto kernel = KernelInfo{};
+
+        const auto build_params = KernelBuildParameters{
+            {"MIOPEN_USE_FP16", static_cast<int>(dtype == miopenHalf)},
+            {"MIOPEN_USE_FP32", static_cast<int>(dtype == miopenFloat)},
+            {"MIOPEN_USE_FP64", static_cast<int>(dtype == miopenDouble)},
+            {"MIOPEN_USE_BFP16", static_cast<int>(dtype == miopenBFloat16)},
+            {"INPUT_TYPE", input_dtype == "bfloat16" ? "ushort" : input_dtype},
+            {"OUTPUT_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
+            {"D_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
+            {"LOCAL_SIZE", LOCAL_SIZE_CON_BWD},
+        };
+
+        result.construction_params.push_back(
+            make_hip_kernel({LOCAL_SIZE_CON_BWD},
+                            {N_total},
+                            "MIOpenSoftmaxCrossEntropyWithLogits.cpp",
+                            "SoftmaxCrossEntropyWithLogitsBackwardContiguous",
+                            build_params));
+    }
+
+    result.invoker_factory = [](const std::vector<Kernel>& kernels) {
+        return [=](const Handle& handle_, const AnyInvokeParams& raw_params) {
+            decltype(auto) kernel = handle_.Run(kernels.front());
+            decltype(auto) params =
+                raw_params.CastTo<miopen::softmaxcrossentropywithlogits::BwdInvokeParams>();
+
+            auto output_grad_tv = get_inner_expanded_tv_1d(deref(params.outputGradDesc));
+            auto backprop_tv    = get_inner_expanded_tv_2d(deref(params.backpropDesc));
+            auto input_tv       = get_inner_expanded_tv_2d(deref(params.inputDesc));
+            auto input_grad_tv  = get_inner_expanded_tv_2d(deref(params.inputGradDesc));
+            auto target_grad_tv = get_inner_expanded_tv_2d(deref(params.targetGradDesc));
+
+            kernel(params.output_grad,
+                   params.backprop,
+                   params.input,
+                   params.input_grad,
+                   params.target_grad,
+                   output_grad_tv,
+                   backprop_tv,
+                   input_tv,
+                   input_grad_tv,
+                   target_grad_tv);
+        };
+    };
+
+    return result;
+}
+
+} // namespace softmaxcrossentropywithlogits
+
+} // namespace solver
+
+} // namespace miopen

--- a/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
+++ b/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
@@ -36,7 +36,7 @@
 #include <miopen/tensor_view.hpp>
 #include <limits>
 
-#define LOCAL_SIZE_CON_BWD 1024
+#define LOCAL_SIZE_CON_BWD 128
 
 namespace miopen {
 

--- a/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
+++ b/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
@@ -66,7 +66,7 @@ ConvSolution SoftmaxCrossEntropyWithLogitsBackwardContiguous::GetSolution(
 
     {
         auto dtype     = problem.GetInputGradDesc().GetType();
-        size_t N_total = problem.GetBatchSize();
+        size_t N_total = problem.GetBatchSize() * LOCAL_SIZE_CON_BWD;
         float infinity = std::numeric_limits<float>::max();
 
         auto kernel = KernelInfo{};

--- a/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
+++ b/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
@@ -78,7 +78,6 @@ ConvSolution SoftmaxCrossEntropyWithLogitsBackwardContiguous::GetSolution(
             {"MIOPEN_USE_BFP16", static_cast<int>(dtype == miopenBFloat16)},
             {"INPUT_TYPE", input_dtype == "bfloat16" ? "ushort" : input_dtype},
             {"OUTPUT_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
-            {"D_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
             {"LOCAL_SIZE", LOCAL_SIZE_CON_BWD},
             {"INFINITY", infinity},
         };
@@ -97,22 +96,15 @@ ConvSolution SoftmaxCrossEntropyWithLogitsBackwardContiguous::GetSolution(
             decltype(auto) params =
                 raw_params.CastTo<miopen::softmaxcrossentropywithlogits::BwdInvokeParams>();
 
-            auto output_grad_tv = get_inner_expanded_tv_1d(deref(params.outputGradDesc));
-            auto backprop_tv    = get_inner_expanded_tv_2d(deref(params.backpropDesc));
             auto input_tv       = get_inner_expanded_tv_2d(deref(params.inputDesc));
-            auto input_grad_tv  = get_inner_expanded_tv_2d(deref(params.inputGradDesc));
-            auto target_grad_tv = get_inner_expanded_tv_2d(deref(params.targetGradDesc));
+            size_t num_class = input_tv.size[1];
 
             kernel(params.output_grad,
                    params.backprop,
                    params.input,
                    params.input_grad,
                    params.target_grad,
-                   output_grad_tv,
-                   backprop_tv,
-                   input_tv,
-                   input_grad_tv,
-                   target_grad_tv);
+                   num_class);
         };
     };
 

--- a/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
+++ b/src/solver/softmaxcrossentropywithlogits/bwd_con_softmaxcrossentropywithlogits.cpp
@@ -34,6 +34,7 @@
 #include <miopen/softmaxcrossentropywithlogits.hpp>
 #include <miopen/target_properties.hpp>
 #include <miopen/tensor_view.hpp>
+#include <limits>
 
 #define LOCAL_SIZE_CON_BWD 1024
 
@@ -65,7 +66,8 @@ ConvSolution SoftmaxCrossEntropyWithLogitsBackwardContiguous::GetSolution(
 
     {
         auto dtype     = problem.GetInputGradDesc().GetType();
-        size_t N_total = problem.GetInputTotal();
+        size_t N_total = problem.GetBatchSize();
+        float infinity = std::numeric_limits<float>::max();
 
         auto kernel = KernelInfo{};
 
@@ -78,6 +80,7 @@ ConvSolution SoftmaxCrossEntropyWithLogitsBackwardContiguous::GetSolution(
             {"OUTPUT_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
             {"D_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
             {"LOCAL_SIZE", LOCAL_SIZE_CON_BWD},
+            {"INFINITY", infinity},
         };
 
         result.construction_params.push_back(

--- a/src/solver/softmaxcrossentropywithlogits/fwd_con_softmaxcrossentropywithlogits.cpp
+++ b/src/solver/softmaxcrossentropywithlogits/fwd_con_softmaxcrossentropywithlogits.cpp
@@ -78,7 +78,6 @@ ConvSolution SoftmaxCrossEntropyWithLogitsForwardContiguous::GetSolution(
             {"MIOPEN_USE_BFP16", static_cast<int>(dtype == miopenBFloat16)},
             {"INPUT_TYPE", input_dtype == "bfloat16" ? "ushort" : input_dtype},
             {"OUTPUT_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
-            {"D_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
             {"LOCAL_SIZE", LOCAL_SIZE_CON_FWD},
             {"INFINITY", infinity},
         };
@@ -98,18 +97,13 @@ ConvSolution SoftmaxCrossEntropyWithLogitsForwardContiguous::GetSolution(
                 raw_params.CastTo<miopen::softmaxcrossentropywithlogits::FwdInvokeParams>();
 
             auto input_tv    = get_inner_expanded_tv_2d(deref(params.inputDesc));
-            auto target_tv   = get_inner_expanded_tv_2d(deref(params.targetDesc));
-            auto output_tv   = get_inner_expanded_tv_1d(deref(params.outputDesc));
-            auto backprop_tv = get_inner_expanded_tv_2d(deref(params.backpropDesc));
+            size_t num_class = input_tv.size[1];
 
             kernel(params.input,
                    params.target,
                    params.output,
                    params.backprop,
-                   input_tv,
-                   target_tv,
-                   output_tv,
-                   backprop_tv);
+                   num_class);
         };
     };
 

--- a/src/solver/softmaxcrossentropywithlogits/fwd_con_softmaxcrossentropywithlogits.cpp
+++ b/src/solver/softmaxcrossentropywithlogits/fwd_con_softmaxcrossentropywithlogits.cpp
@@ -66,7 +66,7 @@ ConvSolution SoftmaxCrossEntropyWithLogitsForwardContiguous::GetSolution(
 
     {
         auto dtype     = problem.GetOutputDesc().GetType();
-        size_t N_total = problem.GetBatchSize();
+        size_t N_total = problem.GetBatchSize() * LOCAL_SIZE_CON_FWD;
         float infinity = std::numeric_limits<float>::max();
 
         auto kernel = KernelInfo{};

--- a/src/solver/softmaxcrossentropywithlogits/fwd_con_softmaxcrossentropywithlogits.cpp
+++ b/src/solver/softmaxcrossentropywithlogits/fwd_con_softmaxcrossentropywithlogits.cpp
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "miopen/conv_solution.hpp"
+#include "miopen/execution_context.hpp"
+#include "miopen/invoke_params.hpp"
+#include <miopen/softmaxcrossentropywithlogits/solvers.hpp>
+
+#include <miopen/softmaxcrossentropywithlogits/invoke_params.hpp>
+#include <miopen/datatype.hpp>
+#include <miopen/softmaxcrossentropywithlogits.hpp>
+#include <miopen/target_properties.hpp>
+#include <miopen/tensor_view.hpp>
+
+#define LOCAL_SIZE_CON_FWD 1024
+
+namespace miopen {
+
+namespace solver {
+
+namespace softmaxcrossentropywithlogits {
+
+bool SoftmaxCrossEntropyWithLogitsForwardContiguous::IsApplicable(
+    const ExecutionContext&,
+    const miopen::softmaxcrossentropywithlogits::FwdProblemDescription& problem) const
+{
+    if(!problem.IsAllContiguous())
+        return false;
+
+    return true;
+}
+
+ConvSolution SoftmaxCrossEntropyWithLogitsForwardContiguous::GetSolution(
+    const ExecutionContext& context,
+    const miopen::softmaxcrossentropywithlogits::FwdProblemDescription& problem) const
+{
+    std::ignore = context;
+
+    auto result       = ConvSolution{miopenStatusSuccess};
+    auto input_dtype  = miopen::GetDataType(problem.GetInputDesc().GetType());
+    auto output_dtype = miopen::GetDataType(problem.GetOutputDesc().GetType());
+
+    {
+        auto dtype     = problem.GetOutputDesc().GetType();
+        size_t N_total = problem.GetBatchSize();
+
+        auto kernel = KernelInfo{};
+
+        const auto build_params = KernelBuildParameters{
+            {"MIOPEN_USE_FP16", static_cast<int>(dtype == miopenHalf)},
+            {"MIOPEN_USE_FP32", static_cast<int>(dtype == miopenFloat)},
+            {"MIOPEN_USE_FP64", static_cast<int>(dtype == miopenDouble)},
+            {"MIOPEN_USE_BFP16", static_cast<int>(dtype == miopenBFloat16)},
+            {"INPUT_TYPE", input_dtype == "bfloat16" ? "ushort" : input_dtype},
+            {"OUTPUT_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
+            {"D_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
+            {"LOCAL_SIZE", LOCAL_SIZE_CON_FWD},
+        };
+
+        result.construction_params.push_back(
+            make_hip_kernel({LOCAL_SIZE_CON_FWD},
+                            {N_total},
+                            "MIOpenSoftmaxCrossEntropyWithLogits.cpp",
+                            "SoftmaxCrossEntropyWithLogitsForwardContiguous",
+                            build_params));
+    }
+
+    result.invoker_factory = [](const std::vector<Kernel>& kernels) {
+        return [=](const Handle& handle_, const AnyInvokeParams& raw_params) {
+            decltype(auto) kernel = handle_.Run(kernels.front());
+            decltype(auto) params =
+                raw_params.CastTo<miopen::softmaxcrossentropywithlogits::FwdInvokeParams>();
+
+            auto input_tv    = get_inner_expanded_tv_2d(deref(params.inputDesc));
+            auto target_tv   = get_inner_expanded_tv_2d(deref(params.targetDesc));
+            auto output_tv   = get_inner_expanded_tv_1d(deref(params.outputDesc));
+            auto backprop_tv = get_inner_expanded_tv_2d(deref(params.backpropDesc));
+
+            kernel(params.input,
+                   params.target,
+                   params.output,
+                   params.backprop,
+                   input_tv,
+                   target_tv,
+                   output_tv,
+                   backprop_tv);
+        };
+    };
+
+    return result;
+}
+
+} // namespace softmaxcrossentropywithlogits
+
+} // namespace solver
+
+} // namespace miopen

--- a/src/solver/softmaxcrossentropywithlogits/fwd_con_softmaxcrossentropywithlogits.cpp
+++ b/src/solver/softmaxcrossentropywithlogits/fwd_con_softmaxcrossentropywithlogits.cpp
@@ -34,6 +34,7 @@
 #include <miopen/softmaxcrossentropywithlogits.hpp>
 #include <miopen/target_properties.hpp>
 #include <miopen/tensor_view.hpp>
+#include <limits>
 
 #define LOCAL_SIZE_CON_FWD 1024
 
@@ -66,6 +67,7 @@ ConvSolution SoftmaxCrossEntropyWithLogitsForwardContiguous::GetSolution(
     {
         auto dtype     = problem.GetOutputDesc().GetType();
         size_t N_total = problem.GetBatchSize();
+        float infinity = std::numeric_limits<float>::max();
 
         auto kernel = KernelInfo{};
 
@@ -78,6 +80,7 @@ ConvSolution SoftmaxCrossEntropyWithLogitsForwardContiguous::GetSolution(
             {"OUTPUT_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
             {"D_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
             {"LOCAL_SIZE", LOCAL_SIZE_CON_FWD},
+            {"INFINITY", infinity},
         };
 
         result.construction_params.push_back(

--- a/src/solver/softmaxcrossentropywithlogits/fwd_con_softmaxcrossentropywithlogits.cpp
+++ b/src/solver/softmaxcrossentropywithlogits/fwd_con_softmaxcrossentropywithlogits.cpp
@@ -36,7 +36,7 @@
 #include <miopen/tensor_view.hpp>
 #include <limits>
 
-#define LOCAL_SIZE_CON_FWD 1024
+#define LOCAL_SIZE_CON_FWD 128
 
 namespace miopen {
 

--- a/test/cpu_softmaxcrossentropywithlogits.hpp
+++ b/test/cpu_softmaxcrossentropywithlogits.hpp
@@ -100,8 +100,6 @@ void cpu_softmaxcrossentropywithlogits_backward(tensor<T> output_grad,
     auto dO_tv = get_inner_expanded_tv_1d(output_grad.desc);
     auto B_tv  = get_inner_expanded_tv_2d(backprop.desc);
     auto I_tv  = get_inner_expanded_tv_2d(input.desc);
-    auto dI_tv = get_inner_expanded_tv_2d(input_grad.desc);
-    auto dT_tv = get_inner_expanded_tv_2d(target_grad.desc);
 
     size_t num_batches = I_tv.size[0];
     size_t num_class   = I_tv.size[1];
@@ -113,6 +111,8 @@ void cpu_softmaxcrossentropywithlogits_backward(tensor<T> output_grad,
 
         if(input_grad_out)
         {
+            auto dI_tv = get_inner_expanded_tv_2d(input_grad.desc);
+
             for(size_t i = 0; i < num_class; ++i)
             {
                 size_t Bidx        = TV2D_IDX(B_tv, gid, i);
@@ -124,6 +124,8 @@ void cpu_softmaxcrossentropywithlogits_backward(tensor<T> output_grad,
 
         if(target_grad_out)
         {
+            auto dT_tv = get_inner_expanded_tv_2d(target_grad.desc);
+
             float max_val = -std::numeric_limits<float>::infinity();
             for(size_t i = 0; i < num_class; ++i)
             {

--- a/test/cpu_softmaxcrossentropywithlogits.hpp
+++ b/test/cpu_softmaxcrossentropywithlogits.hpp
@@ -61,8 +61,13 @@ void cpu_softmaxcrossentropywithlogits_forward(tensor<T> input,
             sum += std::exp(static_cast<float>(input[Iidx]) - max_val);
         }
 
-        float log_sum = std::log(sum);
-        float loss    = 0.0f;
+        float log_sum;
+        if(sum != 0)
+            log_sum = std::log(sum);
+        else
+            log_sum = std::log(std::numeric_limits<float>::epsilon());
+
+        float loss = 0.0f;
         for(size_t i = 0; i < num_class; ++i)
         {
             size_t Iidx = TV2D_IDX(I_tv, gid, i);
@@ -142,7 +147,12 @@ void cpu_softmaxcrossentropywithlogits_backward(tensor<T> output_grad,
                 sum += std::exp(val - max_val);
             }
 
-            float log_val = std::log(sum);
+            float log_val;
+            if(sum != 0)
+                log_val = std::log(sum);
+            else
+                log_val = std::log(std::numeric_limits<float>::epsilon());
+
             for(size_t i = 0; i < num_class; ++i)
             {
                 size_t Iidx     = TV2D_IDX(I_tv, gid, i);

--- a/test/cpu_softmaxcrossentropywithlogits.hpp
+++ b/test/cpu_softmaxcrossentropywithlogits.hpp
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef GUARD_CPU_SOFTMAXCROSSENTROPYWITHLOGITS_HPP
+#define GUARD_CPU_SOFTMAXCROSSENTROPYWITHLOGITS_HPP
+
+#include "tensor_holder.hpp"
+#include <miopen/tensor_view.hpp>
+
+template <class T>
+void cpu_softmaxcrossentropywithlogits_forward(tensor<T> input,
+                                               tensor<T> target,
+                                               tensor<T>& output,
+                                               tensor<T>& backprop)
+{
+    auto I_tv = get_inner_expanded_tv_2d(input.desc);
+    auto T_tv = get_inner_expanded_tv_2d(target.desc);
+    auto O_tv = get_inner_expanded_tv_1d(output.desc);
+    auto B_tv = get_inner_expanded_tv_2d(backprop.desc);
+
+    size_t num_batches = I_tv.size[0];
+    size_t num_class   = I_tv.size[1];
+
+    for(size_t gid = 0; gid < num_batches; ++gid)
+    {
+        float max_val = -std::numeric_limits<float>::infinity();
+
+        for(size_t i = 0; i < num_class; ++i)
+        {
+            size_t Iidx = TV2D_IDX(I_tv, gid, i);
+            float val   = static_cast<float>(input[Iidx]);
+            max_val     = std::max(max_val, val);
+        }
+
+        float sum = 0.0f;
+        for(size_t i = 0; i < num_class; ++i)
+        {
+            size_t Iidx = TV2D_IDX(I_tv, gid, i);
+            sum += std::exp(static_cast<float>(input[Iidx]) - max_val);
+        }
+
+        float log_sum = std::log(sum);
+        float loss    = 0.0f;
+        for(size_t i = 0; i < num_class; ++i)
+        {
+            size_t Iidx = TV2D_IDX(I_tv, gid, i);
+            size_t Tidx = TV2D_IDX(T_tv, gid, i);
+            float val   = static_cast<float>(input[Iidx]);
+            float label = static_cast<float>(target[Tidx]);
+            loss += label * (log_sum - val + max_val);
+        }
+
+        size_t Oidx  = TV1D_IDX(O_tv, gid);
+        output[Oidx] = static_cast<T>(loss);
+
+        for(size_t i = 0; i < num_class; ++i)
+        {
+            size_t Iidx        = TV2D_IDX(I_tv, gid, i);
+            size_t Tidx        = TV2D_IDX(T_tv, gid, i);
+            size_t Bidx        = TV2D_IDX(B_tv, gid, i);
+            float val          = static_cast<float>(input[Iidx]);
+            float label        = static_cast<float>(target[Tidx]);
+            float backprop_val = std::exp(val - max_val) / sum - label;
+            backprop[Bidx]     = static_cast<T>(backprop_val);
+        }
+    }
+}
+
+template <class T>
+void cpu_softmaxcrossentropywithlogits_backward(tensor<T> output_grad,
+                                                tensor<T> backprop,
+                                                tensor<T> input,
+                                                tensor<T>& input_grad,
+                                                tensor<T>& target_grad,
+                                                bool input_grad_out,
+                                                bool target_grad_out)
+{
+    auto dO_tv = get_inner_expanded_tv_1d(output_grad.desc);
+    auto B_tv  = get_inner_expanded_tv_2d(backprop.desc);
+    auto I_tv  = get_inner_expanded_tv_2d(input.desc);
+    auto dI_tv = get_inner_expanded_tv_2d(input_grad.desc);
+    auto dT_tv = get_inner_expanded_tv_2d(target_grad.desc);
+
+    size_t num_batches = I_tv.size[0];
+    size_t num_class   = I_tv.size[1];
+
+    for(size_t gid = 0; gid < num_batches; ++gid)
+    {
+        size_t dOidx          = TV1D_IDX(dO_tv, gid);
+        float output_grad_val = static_cast<float>(output_grad[dOidx]);
+
+        if(input_grad_out)
+        {
+            for(size_t i = 0; i < num_class; ++i)
+            {
+                size_t Bidx        = TV2D_IDX(B_tv, gid, i);
+                size_t dIidx       = TV2D_IDX(dI_tv, gid, i);
+                float backprop_val = static_cast<float>(backprop[Bidx]);
+                input_grad[dIidx]  = static_cast<T>(output_grad_val * backprop_val);
+            }
+        }
+
+        if(target_grad_out)
+        {
+            float max_val = -std::numeric_limits<float>::infinity();
+            for(size_t i = 0; i < num_class; ++i)
+            {
+                size_t Iidx = TV2D_IDX(I_tv, gid, i);
+                float val   = static_cast<float>(input[Iidx]);
+                max_val     = std::max(max_val, val);
+            }
+
+            float sum = 0.0f;
+            for(size_t i = 0; i < num_class; ++i)
+            {
+                size_t Iidx = TV2D_IDX(I_tv, gid, i);
+                float val   = static_cast<float>(input[Iidx]);
+                sum += std::exp(val - max_val);
+            }
+
+            float log_val = std::log(sum);
+            for(size_t i = 0; i < num_class; ++i)
+            {
+                size_t Iidx     = TV2D_IDX(I_tv, gid, i);
+                float logit_val = static_cast<float>(input[Iidx]);
+                size_t Tidx     = TV2D_IDX(dT_tv, gid, i);
+                target_grad[Tidx] =
+                    static_cast<T>((max_val + log_val - logit_val) * output_grad_val);
+            }
+        }
+    }
+}
+
+#endif // GUARD_CPU_SOFTMAXCROSSENTROPYWITHLOGITS_HPP

--- a/test/gtest/softmaxcrossentropywithlogits.cpp
+++ b/test/gtest/softmaxcrossentropywithlogits.cpp
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "miopen/bfloat16.hpp"
+#include <miopen/env.hpp>
+#include "softmaxcrossentropywithlogits.hpp"
+
+MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_TEST_FLOAT_ARG)
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_TEST_ALL)
+
+namespace softmaxcrossentropywithlogits {
+
+std::string GetFloatArg()
+{
+    const auto& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    if(tmp.empty())
+    {
+        return "";
+    }
+    return tmp;
+}
+
+struct SoftmaxCrossEntropyWithLogitsTestFloat : SoftmaxCrossEntropyWithLogitsTest<float>
+{
+};
+
+// struct SoftmaxCrossEntropyWithLogitsTestHalf : SoftmaxCrossEntropyWithLogitsTest<half>
+// {
+// };
+
+// struct SoftmaxCrossEntropyWithLogitsTestBFloat16 : SoftmaxCrossEntropyWithLogitsTest<bfloat16>
+// {
+// };
+
+// struct SoftmaxCrossEntropyWithLogitsTestFloatBwd : SoftmaxCrossEntropyWithLogitsTestBwd<float>
+// {
+// };
+
+// struct SoftmaxCrossEntropyWithLogitsTestHalfBwd : SoftmaxCrossEntropyWithLogitsTestBwd<half>
+// {
+// };
+
+// struct SoftmaxCrossEntropyWithLogitsTestBFloat16Bwd :
+// SoftmaxCrossEntropyWithLogitsTestBwd<bfloat16>
+// {
+// };
+
+} // namespace softmaxcrossentropywithlogits
+using namespace softmaxcrossentropywithlogits;
+
+// FORWARD TEST
+TEST_P(SoftmaxCrossEntropyWithLogitsTestFloat, SoftmaxCrossEntropyWithLogitsTest)
+{
+    if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--float") ||
+       GetFloatArg() == "--testall")
+    {
+        RunTest();
+        Verify();
+    }
+    else
+    {
+        GTEST_SKIP();
+    }
+};
+
+// TEST_P(SoftmaxCrossEntropyWithLogitsTestHalf, SoftmaxCrossEntropyWithLogitsTest)
+// {
+//     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--half") ||
+//        GetFloatArg() == "--testall")
+//     {
+//         RunTest();
+//         Verify();
+//     }
+//     else
+//     {
+//         GTEST_SKIP();
+//     }
+// };
+
+// TEST_P(SoftmaxCrossEntropyWithLogitsTestBFloat16, SoftmaxCrossEntropyWithLogitsTest)
+// {
+//     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--bfloat16") ||
+//        GetFloatArg() == "--testall")
+//     {
+//         RunTest();
+//         Verify();
+//     }
+//     else
+//     {
+//         GTEST_SKIP();
+//     }
+// };
+
+INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
+                         SoftmaxCrossEntropyWithLogitsTestFloat,
+                         testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
+// INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
+//                          SoftmaxCrossEntropyWithLogitsTestHalf,
+//                          testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
+// INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
+//                          SoftmaxCrossEntropyWithLogitsTestBFloat16,
+//                          testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
+
+// // BACKWARD TEST
+// TEST_P(SoftmaxCrossEntropyWithLogitsTestFloatBwd, SoftmaxCrossEntropyWithLogitsTestBwd)
+// {
+//     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--float") ||
+//        GetFloatArg() == "--testall")
+//     {
+//         RunTest();
+//         Verify();
+//     }
+//     else
+//     {
+//         GTEST_SKIP();
+//     }
+// };
+
+// TEST_P(SoftmaxCrossEntropyWithLogitsTestHalfBwd, SoftmaxCrossEntropyWithLogitsTestBwd)
+// {
+//     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--half") ||
+//        GetFloatArg() == "--testall")
+//     {
+//         RunTest();
+//         Verify();
+//     }
+//     else
+//     {
+//         GTEST_SKIP();
+//     }
+// };
+
+// TEST_P(SoftmaxCrossEntropyWithLogitsTestBFloat16Bwd, SoftmaxCrossEntropyWithLogitsTestBwd)
+// {
+//     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--bfloat16") ||
+//        GetFloatArg() == "--testall")
+//     {
+//         RunTest();
+//         Verify();
+//     }
+//     else
+//     {
+//         GTEST_SKIP();
+//     }
+// };
+
+// INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
+//                          SoftmaxCrossEntropyWithLogitsTestFloatBwd,
+//                          testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
+// INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
+//                          SoftmaxCrossEntropyWithLogitsTestHalfBwd,
+//                          testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
+// INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
+//                          SoftmaxCrossEntropyWithLogitsTestBFloat16Bwd,
+//                          testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));

--- a/test/gtest/softmaxcrossentropywithlogits.cpp
+++ b/test/gtest/softmaxcrossentropywithlogits.cpp
@@ -46,26 +46,25 @@ struct SoftmaxCrossEntropyWithLogitsTestFloat : SoftmaxCrossEntropyWithLogitsTes
 {
 };
 
-// struct SoftmaxCrossEntropyWithLogitsTestHalf : SoftmaxCrossEntropyWithLogitsTest<half>
-// {
-// };
+struct SoftmaxCrossEntropyWithLogitsTestHalf : SoftmaxCrossEntropyWithLogitsTest<half>
+{
+};
 
-// struct SoftmaxCrossEntropyWithLogitsTestBFloat16 : SoftmaxCrossEntropyWithLogitsTest<bfloat16>
-// {
-// };
+struct SoftmaxCrossEntropyWithLogitsTestBFloat16 : SoftmaxCrossEntropyWithLogitsTest<bfloat16>
+{
+};
 
-// struct SoftmaxCrossEntropyWithLogitsTestFloatBwd : SoftmaxCrossEntropyWithLogitsTestBwd<float>
-// {
-// };
+struct SoftmaxCrossEntropyWithLogitsTestFloatBwd : SoftmaxCrossEntropyWithLogitsTestBwd<float>
+{
+};
 
-// struct SoftmaxCrossEntropyWithLogitsTestHalfBwd : SoftmaxCrossEntropyWithLogitsTestBwd<half>
-// {
-// };
+struct SoftmaxCrossEntropyWithLogitsTestHalfBwd : SoftmaxCrossEntropyWithLogitsTestBwd<half>
+{
+};
 
-// struct SoftmaxCrossEntropyWithLogitsTestBFloat16Bwd :
-// SoftmaxCrossEntropyWithLogitsTestBwd<bfloat16>
-// {
-// };
+struct SoftmaxCrossEntropyWithLogitsTestBFloat16Bwd : SoftmaxCrossEntropyWithLogitsTestBwd<bfloat16>
+{
+};
 
 } // namespace softmaxcrossentropywithlogits
 using namespace softmaxcrossentropywithlogits;
@@ -85,93 +84,93 @@ TEST_P(SoftmaxCrossEntropyWithLogitsTestFloat, SoftmaxCrossEntropyWithLogitsTest
     }
 };
 
-// TEST_P(SoftmaxCrossEntropyWithLogitsTestHalf, SoftmaxCrossEntropyWithLogitsTest)
-// {
-//     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--half") ||
-//        GetFloatArg() == "--testall")
-//     {
-//         RunTest();
-//         Verify();
-//     }
-//     else
-//     {
-//         GTEST_SKIP();
-//     }
-// };
+TEST_P(SoftmaxCrossEntropyWithLogitsTestHalf, SoftmaxCrossEntropyWithLogitsTest)
+{
+    if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--half") ||
+       GetFloatArg() == "--testall")
+    {
+        RunTest();
+        Verify();
+    }
+    else
+    {
+        GTEST_SKIP();
+    }
+};
 
-// TEST_P(SoftmaxCrossEntropyWithLogitsTestBFloat16, SoftmaxCrossEntropyWithLogitsTest)
-// {
-//     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--bfloat16") ||
-//        GetFloatArg() == "--testall")
-//     {
-//         RunTest();
-//         Verify();
-//     }
-//     else
-//     {
-//         GTEST_SKIP();
-//     }
-// };
+TEST_P(SoftmaxCrossEntropyWithLogitsTestBFloat16, SoftmaxCrossEntropyWithLogitsTest)
+{
+    if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--bfloat16") ||
+       GetFloatArg() == "--testall")
+    {
+        RunTest();
+        Verify();
+    }
+    else
+    {
+        GTEST_SKIP();
+    }
+};
 
 INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
                          SoftmaxCrossEntropyWithLogitsTestFloat,
                          testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
-// INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
-//                          SoftmaxCrossEntropyWithLogitsTestHalf,
-//                          testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
-// INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
-//                          SoftmaxCrossEntropyWithLogitsTestBFloat16,
-//                          testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
+                         SoftmaxCrossEntropyWithLogitsTestHalf,
+                         testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
+                         SoftmaxCrossEntropyWithLogitsTestBFloat16,
+                         testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
 
-// // BACKWARD TEST
-// TEST_P(SoftmaxCrossEntropyWithLogitsTestFloatBwd, SoftmaxCrossEntropyWithLogitsTestBwd)
-// {
-//     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--float") ||
-//        GetFloatArg() == "--testall")
-//     {
-//         RunTest();
-//         Verify();
-//     }
-//     else
-//     {
-//         GTEST_SKIP();
-//     }
-// };
+// BACKWARD TEST
+TEST_P(SoftmaxCrossEntropyWithLogitsTestFloatBwd, SoftmaxCrossEntropyWithLogitsTestBwd)
+{
+    if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--float") ||
+       GetFloatArg() == "--testall")
+    {
+        RunTest();
+        Verify();
+    }
+    else
+    {
+        GTEST_SKIP();
+    }
+};
 
-// TEST_P(SoftmaxCrossEntropyWithLogitsTestHalfBwd, SoftmaxCrossEntropyWithLogitsTestBwd)
-// {
-//     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--half") ||
-//        GetFloatArg() == "--testall")
-//     {
-//         RunTest();
-//         Verify();
-//     }
-//     else
-//     {
-//         GTEST_SKIP();
-//     }
-// };
+TEST_P(SoftmaxCrossEntropyWithLogitsTestHalfBwd, SoftmaxCrossEntropyWithLogitsTestBwd)
+{
+    if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--half") ||
+       GetFloatArg() == "--testall")
+    {
+        RunTest();
+        Verify();
+    }
+    else
+    {
+        GTEST_SKIP();
+    }
+};
 
-// TEST_P(SoftmaxCrossEntropyWithLogitsTestBFloat16Bwd, SoftmaxCrossEntropyWithLogitsTestBwd)
-// {
-//     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--bfloat16") ||
-//        GetFloatArg() == "--testall")
-//     {
-//         RunTest();
-//         Verify();
-//     }
-//     else
-//     {
-//         GTEST_SKIP();
-//     }
-// };
+TEST_P(SoftmaxCrossEntropyWithLogitsTestBFloat16Bwd, SoftmaxCrossEntropyWithLogitsTestBwd)
+{
+    if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--bfloat16") ||
+       GetFloatArg() == "--testall")
+    {
+        RunTest();
+        Verify();
+    }
+    else
+    {
+        GTEST_SKIP();
+    }
+};
 
-// INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
-//                          SoftmaxCrossEntropyWithLogitsTestFloatBwd,
-//                          testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
-// INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
-//                          SoftmaxCrossEntropyWithLogitsTestHalfBwd,
-//                          testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
-// INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
-//                          SoftmaxCrossEntropyWithLogitsTestBFloat16Bwd,
-//                          testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
+                         SoftmaxCrossEntropyWithLogitsTestFloatBwd,
+                         testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
+                         SoftmaxCrossEntropyWithLogitsTestHalfBwd,
+                         testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
+                         SoftmaxCrossEntropyWithLogitsTestBFloat16Bwd,
+                         testing::ValuesIn(SoftmaxCrossEntropyWithLogitsTestConfigs()));

--- a/test/gtest/softmaxcrossentropywithlogits.cpp
+++ b/test/gtest/softmaxcrossentropywithlogits.cpp
@@ -73,7 +73,7 @@ using namespace softmaxcrossentropywithlogits;
 TEST_P(SoftmaxCrossEntropyWithLogitsTestFloat, SoftmaxCrossEntropyWithLogitsTest)
 {
     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--float") ||
-       GetFloatArg() == "--testall")
+       miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
     {
         RunTest();
         Verify();
@@ -87,7 +87,7 @@ TEST_P(SoftmaxCrossEntropyWithLogitsTestFloat, SoftmaxCrossEntropyWithLogitsTest
 TEST_P(SoftmaxCrossEntropyWithLogitsTestHalf, SoftmaxCrossEntropyWithLogitsTest)
 {
     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--half") ||
-       GetFloatArg() == "--testall")
+       miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
     {
         RunTest();
         Verify();
@@ -101,7 +101,7 @@ TEST_P(SoftmaxCrossEntropyWithLogitsTestHalf, SoftmaxCrossEntropyWithLogitsTest)
 TEST_P(SoftmaxCrossEntropyWithLogitsTestBFloat16, SoftmaxCrossEntropyWithLogitsTest)
 {
     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--bfloat16") ||
-       GetFloatArg() == "--testall")
+       miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
     {
         RunTest();
         Verify();
@@ -126,7 +126,7 @@ INSTANTIATE_TEST_SUITE_P(SoftmaxCrossEntropyWithLogitsTestSet,
 TEST_P(SoftmaxCrossEntropyWithLogitsTestFloatBwd, SoftmaxCrossEntropyWithLogitsTestBwd)
 {
     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--float") ||
-       GetFloatArg() == "--testall")
+       miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
     {
         RunTest();
         Verify();
@@ -140,7 +140,7 @@ TEST_P(SoftmaxCrossEntropyWithLogitsTestFloatBwd, SoftmaxCrossEntropyWithLogitsT
 TEST_P(SoftmaxCrossEntropyWithLogitsTestHalfBwd, SoftmaxCrossEntropyWithLogitsTestBwd)
 {
     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--half") ||
-       GetFloatArg() == "--testall")
+       miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
     {
         RunTest();
         Verify();
@@ -154,7 +154,7 @@ TEST_P(SoftmaxCrossEntropyWithLogitsTestHalfBwd, SoftmaxCrossEntropyWithLogitsTe
 TEST_P(SoftmaxCrossEntropyWithLogitsTestBFloat16Bwd, SoftmaxCrossEntropyWithLogitsTestBwd)
 {
     if((miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && GetFloatArg() == "--bfloat16") ||
-       GetFloatArg() == "--testall")
+       miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
     {
         RunTest();
         Verify();

--- a/test/gtest/softmaxcrossentropywithlogits.hpp
+++ b/test/gtest/softmaxcrossentropywithlogits.hpp
@@ -65,7 +65,7 @@ struct SoftmaxCrossEntropyWithLogitsTestCase
 inline std::vector<SoftmaxCrossEntropyWithLogitsTestCase> SoftmaxCrossEntropyWithLogitsTestConfigs()
 {
     return {
-        // {{2000, 3000}, true},
+        {{2000, 3000}, true},
         {{768, 200}, true},
         {{768, 128}, true},
     };

--- a/test/gtest/softmaxcrossentropywithlogits.hpp
+++ b/test/gtest/softmaxcrossentropywithlogits.hpp
@@ -151,8 +151,6 @@ protected:
         cpu_softmaxcrossentropywithlogits_forward<T>(input, target, ref_output, ref_backprop);
 
         status = miopen::SoftmaxCrossEntropyWithLogitsForward(handle,
-                                                              workspace_dev.get(),
-                                                              ws_sizeInBytes,
                                                               input.desc,
                                                               input_dev.get(),
                                                               target.desc,
@@ -193,16 +191,11 @@ protected:
     tensor<T> ref_output;
     tensor<T> backprop;
     tensor<T> ref_backprop;
-    tensor<T> workspace;
-    tensor<T> ref_workspace;
 
     miopen::Allocator::ManageDataPtr input_dev;
     miopen::Allocator::ManageDataPtr target_dev;
-    miopen::Allocator::ManageDataPtr workspace_dev;
     miopen::Allocator::ManageDataPtr output_dev;
     miopen::Allocator::ManageDataPtr backprop_dev;
-
-    size_t ws_sizeInBytes = 0;
 };
 
 // BACKWARD TEST
@@ -274,8 +267,6 @@ protected:
             output_grad, backprop, input, ref_input_grad, ref_target_grad, true, true);
 
         status = miopen::SoftmaxCrossEntropyWithLogitsBackward(handle,
-                                                               workspace_dev.get(),
-                                                               ws_sizeInBytes,
                                                                output_grad.desc,
                                                                output_grad_dev.get(),
                                                                backprop.desc,
@@ -319,18 +310,13 @@ protected:
     tensor<T> input;
     tensor<T> input_grad;
     tensor<T> target_grad;
-    tensor<T> workspace;
 
     tensor<T> ref_input_grad;
     tensor<T> ref_target_grad;
-    tensor<T> ref_workspace;
 
     miopen::Allocator::ManageDataPtr output_grad_dev;
     miopen::Allocator::ManageDataPtr backprop_dev;
     miopen::Allocator::ManageDataPtr input_dev;
     miopen::Allocator::ManageDataPtr input_grad_dev;
     miopen::Allocator::ManageDataPtr target_grad_dev;
-    miopen::Allocator::ManageDataPtr workspace_dev;
-
-    size_t ws_sizeInBytes = 0;
 };

--- a/test/gtest/softmaxcrossentropywithlogits.hpp
+++ b/test/gtest/softmaxcrossentropywithlogits.hpp
@@ -1,0 +1,346 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "../driver/tensor_driver.hpp"
+#include "cpu_softmaxcrossentropywithlogits.hpp"
+#include "get_handle.hpp"
+#include "random.hpp"
+#include "tensor_holder.hpp"
+#include "verify.hpp"
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <miopen/softmaxcrossentropywithlogits.hpp>
+#include <miopen/miopen.h>
+#include <vector>
+
+inline std::ostream& operator<<(std::ostream& os, const std::vector<size_t>& v)
+{
+    os << '{';
+    for(int i = 0; i < v.size(); ++i)
+    {
+        if(i != 0)
+            os << ',';
+        os << v[i];
+    }
+    os << '}';
+    return os;
+}
+
+struct SoftmaxCrossEntropyWithLogitsTestCase
+{
+    std::vector<size_t> input;
+    bool contiguous;
+
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const SoftmaxCrossEntropyWithLogitsTestCase& tc)
+    {
+        return os << " input:" << tc.input << " contiguous:" << tc.contiguous;
+    }
+
+    std::vector<size_t> GetInput() const { return input; }
+};
+
+inline std::vector<SoftmaxCrossEntropyWithLogitsTestCase> SoftmaxCrossEntropyWithLogitsTestConfigs()
+{
+    return {
+        {{20, 30}, true},
+        // {{768, 200}, true},
+        // {{768, 128}, true},
+    };
+}
+
+inline std::vector<size_t> GetStrides(std::vector<size_t> input, bool contiguous)
+{
+    if(!contiguous)
+        std::swap(input.front(), input.back());
+    std::vector<size_t> strides(input.size());
+    strides.back() = 1;
+    for(int i = input.size() - 2; i >= 0; --i)
+        strides[i] = strides[i + 1] * input[i + 1];
+    if(!contiguous)
+        std::swap(strides.front(), strides.back());
+    return strides;
+}
+
+// FORWARD TEST
+template <typename T = float>
+struct SoftmaxCrossEntropyWithLogitsTest
+    : public ::testing::TestWithParam<SoftmaxCrossEntropyWithLogitsTestCase>
+{
+protected:
+    void SetUp() override
+    {
+        auto&& handle                        = get_handle();
+        softmaxcrossentropywithlogits_config = GetParam();
+
+        auto in_dim       = softmaxcrossentropywithlogits_config.GetInput();
+        auto tar_dim      = in_dim;
+        auto out_dim      = std::vector<size_t>({in_dim[0]});
+        auto backprop_dim = in_dim;
+        auto contiguous   = softmaxcrossentropywithlogits_config.contiguous;
+        auto num_classes  = in_dim[1];
+
+        auto gen_input_value = [](auto...) {
+            return prng::gen_A_to_B<T>(static_cast<T>(-5.0f), static_cast<T>(1.0f));
+        };
+
+        auto in_strides = GetStrides(in_dim, contiguous);
+        input           = tensor<T>{in_dim, in_strides}.generate(gen_input_value);
+
+        auto tar_strides = GetStrides(tar_dim, true);
+        target           = tensor<T>{tar_dim, tar_strides};
+        for(int i = 0; i < tar_dim[0]; i++)
+        {
+            for(int j = 0; j < tar_dim[1]; j++)
+            {
+                if(j == i % num_classes)
+                    target[i * num_classes + j] = (static_cast<T>(1.0f));
+                else
+                    target[i * num_classes + j] = (static_cast<T>(0.0f));
+            }
+        }
+
+        auto out_strides = GetStrides(out_dim, true);
+        output           = tensor<T>{out_dim, out_strides};
+        std::fill(output.begin(), output.end(), std::numeric_limits<T>::quiet_NaN());
+
+        ref_output = tensor<T>{out_dim, out_strides};
+        std::fill(ref_output.begin(), ref_output.end(), std::numeric_limits<T>::quiet_NaN());
+
+        auto backprop_strides = GetStrides(backprop_dim, true);
+        backprop              = tensor<T>{backprop_dim, backprop_strides};
+        std::fill(backprop.begin(), backprop.end(), std::numeric_limits<T>::quiet_NaN());
+
+        ref_backprop = tensor<T>{backprop_dim, backprop_strides};
+        std::fill(ref_backprop.begin(), ref_backprop.end(), std::numeric_limits<T>::quiet_NaN());
+
+        input_dev    = handle.Write(input.data);
+        target_dev   = handle.Write(target.data);
+        output_dev   = handle.Write(output.data);
+        backprop_dev = handle.Write(backprop.data);
+    }
+
+    void RunTest()
+    {
+        auto&& handle = get_handle();
+
+        miopenStatus_t status;
+
+        cpu_softmaxcrossentropywithlogits_forward<T>(input, target, ref_output, ref_backprop);
+
+        status = miopen::SoftmaxCrossEntropyWithLogitsForward(handle,
+                                                              workspace_dev.get(),
+                                                              ws_sizeInBytes,
+                                                              input.desc,
+                                                              input_dev.get(),
+                                                              target.desc,
+                                                              target_dev.get(),
+                                                              output.desc,
+                                                              output_dev.get(),
+                                                              backprop.desc,
+                                                              backprop_dev.get());
+
+        fflush(stdout);
+
+        EXPECT_EQ(status, miopenStatusSuccess);
+
+        output.data   = handle.Read<T>(output_dev, output.data.size());
+        backprop.data = handle.Read<T>(backprop_dev, backprop.data.size());
+    }
+
+    void Verify()
+    {
+        double threshold = std::numeric_limits<T>::epsilon();
+
+        auto error = miopen::rms_range(ref_output, output);
+        for(int i = 0; i < output.data.size(); i++)
+        {
+            std::cout << "CPU output: " << ref_output[i] << " GPU output: " << output[i]
+                      << std::endl;
+        }
+        EXPECT_TRUE(miopen::range_distance(ref_output) == miopen::range_distance(output));
+        EXPECT_TRUE(error < threshold * 10) << "Error output beyond tolerance Error:" << error
+                                            << ",  Thresholdx10: " << threshold * 10;
+
+        auto backprop_error = miopen::rms_range(ref_backprop, backprop);
+        for(int i = 0; i < backprop.data.size(); i++)
+        {
+            std::cout << "CPU backprop: " << ref_backprop[i] << " GPU backprop: " << backprop[i]
+                      << std::endl;
+        }
+        EXPECT_TRUE(miopen::range_distance(ref_backprop) == miopen::range_distance(backprop));
+        EXPECT_TRUE(backprop_error < threshold * 10)
+            << "Error backprop beyond tolerance Error:" << backprop_error
+            << ",  Thresholdx10: " << threshold * 10;
+    }
+    SoftmaxCrossEntropyWithLogitsTestCase softmaxcrossentropywithlogits_config;
+
+    tensor<T> input;
+    tensor<T> target;
+    tensor<T> output;
+    tensor<T> ref_output;
+    tensor<T> backprop;
+    tensor<T> ref_backprop;
+    tensor<T> workspace;
+    tensor<T> ref_workspace;
+
+    miopen::Allocator::ManageDataPtr input_dev;
+    miopen::Allocator::ManageDataPtr target_dev;
+    miopen::Allocator::ManageDataPtr workspace_dev;
+    miopen::Allocator::ManageDataPtr output_dev;
+    miopen::Allocator::ManageDataPtr backprop_dev;
+
+    size_t ws_sizeInBytes = 0;
+};
+
+// BACKWARD TEST
+template <typename T = float>
+struct SoftmaxCrossEntropyWithLogitsTestBwd
+    : public ::testing::TestWithParam<SoftmaxCrossEntropyWithLogitsTestCase>
+{
+protected:
+    void SetUp() override
+    {
+        auto&& handle                        = get_handle();
+        softmaxcrossentropywithlogits_config = GetParam();
+
+        auto in_dim       = softmaxcrossentropywithlogits_config.GetInput();
+        auto backprop_dim = in_dim;
+        auto out_grad_dim = std::vector<size_t>({in_dim[0]});
+        auto in_grad_dim  = in_dim;
+        auto tar_grad_dim = in_dim;
+
+        auto gen_output_grad_value = [](auto...) {
+            return prng::gen_A_to_B<T>(static_cast<T>(-5.0f), static_cast<T>(5.0f));
+        };
+
+        auto gen_backprop_value = [](auto...) {
+            return prng::gen_A_to_B<T>(static_cast<T>(-5.0f), static_cast<T>(5.0f));
+        };
+
+        auto gen_input_value = [](auto...) {
+            return prng::gen_A_to_B<T>(static_cast<T>(-5.0f), static_cast<T>(5.0f));
+        };
+
+        auto out_grad_strides = GetStrides(out_grad_dim, true);
+        output_grad = tensor<T>{out_grad_dim, out_grad_strides}.generate(gen_output_grad_value);
+
+        auto backprop_strides = GetStrides(backprop_dim, true);
+        backprop = tensor<T>{backprop_dim, backprop_strides}.generate(gen_backprop_value);
+
+        auto in_strides = GetStrides(in_dim, true);
+        input           = tensor<T>{in_dim, in_strides}.generate(gen_input_value);
+
+        input_grad = tensor<T>{in_grad_dim, in_strides};
+        std::fill(input_grad.begin(), input_grad.end(), std::numeric_limits<T>::quiet_NaN());
+
+        target_grad = tensor<T>{tar_grad_dim, in_strides};
+        std::fill(target_grad.begin(), target_grad.end(), std::numeric_limits<T>::quiet_NaN());
+
+        ref_input_grad = tensor<T>{in_grad_dim, in_strides};
+        std::fill(
+            ref_input_grad.begin(), ref_input_grad.end(), std::numeric_limits<T>::quiet_NaN());
+
+        ref_target_grad = tensor<T>{tar_grad_dim, in_strides};
+        std::fill(
+            ref_target_grad.begin(), ref_target_grad.end(), std::numeric_limits<T>::quiet_NaN());
+
+        output_grad_dev = handle.Write(output_grad.data);
+        backprop_dev    = handle.Write(backprop.data);
+        input_dev       = handle.Write(input.data);
+        input_grad_dev  = handle.Write(input_grad.data);
+        target_grad_dev = handle.Write(target_grad.data);
+    }
+
+    void RunTest()
+    {
+        auto&& handle = get_handle();
+
+        miopenStatus_t status;
+
+        cpu_softmaxcrossentropywithlogits_backward<T>(
+            output_grad, backprop, input, ref_input_grad, ref_target_grad, true, true);
+
+        status = miopen::SoftmaxCrossEntropyWithLogitsBackward(handle,
+                                                               workspace_dev.get(),
+                                                               ws_sizeInBytes,
+                                                               output_grad.desc,
+                                                               output_grad_dev.get(),
+                                                               backprop.desc,
+                                                               backprop_dev.get(),
+                                                               input.desc,
+                                                               input_dev.get(),
+                                                               input_grad.desc,
+                                                               input_grad_dev.get(),
+                                                               target_grad.desc,
+                                                               target_grad_dev.get());
+
+        fflush(stdout);
+
+        EXPECT_EQ(status, miopenStatusSuccess);
+
+        input_grad.data  = handle.Read<T>(input_grad_dev, input_grad.data.size());
+        target_grad.data = handle.Read<T>(target_grad_dev, target_grad.data.size());
+    }
+
+    void Verify()
+    {
+        double threshold = std::numeric_limits<T>::epsilon();
+
+        auto error1 = miopen::rms_range(ref_input_grad, input_grad);
+
+        EXPECT_TRUE(miopen::range_distance(ref_input_grad) == miopen::range_distance(input_grad));
+        EXPECT_TRUE(error1 < threshold * 10) << "Error input grad beyond tolerance Error:" << error1
+                                             << ",  Thresholdx10: " << threshold * 10;
+
+        auto error2 = miopen::rms_range(ref_target_grad, target_grad);
+
+        EXPECT_TRUE(miopen::range_distance(ref_target_grad) == miopen::range_distance(target_grad));
+        EXPECT_TRUE(error2 < threshold * 10)
+            << "Error target grad beyond tolerance Error:" << error2
+            << ",  Thresholdx10: " << threshold * 10;
+    }
+    SoftmaxCrossEntropyWithLogitsTestCase softmaxcrossentropywithlogits_config;
+
+    tensor<T> output_grad;
+    tensor<T> backprop;
+    tensor<T> input;
+    tensor<T> input_grad;
+    tensor<T> target_grad;
+    tensor<T> workspace;
+
+    tensor<T> ref_input_grad;
+    tensor<T> ref_target_grad;
+    tensor<T> ref_workspace;
+
+    miopen::Allocator::ManageDataPtr output_grad_dev;
+    miopen::Allocator::ManageDataPtr backprop_dev;
+    miopen::Allocator::ManageDataPtr input_dev;
+    miopen::Allocator::ManageDataPtr input_grad_dev;
+    miopen::Allocator::ManageDataPtr target_grad_dev;
+    miopen::Allocator::ManageDataPtr workspace_dev;
+
+    size_t ws_sizeInBytes = 0;
+};

--- a/test/gtest/softmaxcrossentropywithlogits.hpp
+++ b/test/gtest/softmaxcrossentropywithlogits.hpp
@@ -65,9 +65,9 @@ struct SoftmaxCrossEntropyWithLogitsTestCase
 inline std::vector<SoftmaxCrossEntropyWithLogitsTestCase> SoftmaxCrossEntropyWithLogitsTestConfigs()
 {
     return {
-        {{20, 30}, true},
-        // {{768, 200}, true},
-        // {{768, 128}, true},
+        // {{2000, 3000}, true},
+        {{768, 200}, true},
+        {{768, 128}, true},
     };
 }
 
@@ -175,21 +175,11 @@ protected:
         double threshold = std::numeric_limits<T>::epsilon();
 
         auto error = miopen::rms_range(ref_output, output);
-        for(int i = 0; i < output.data.size(); i++)
-        {
-            std::cout << "CPU output: " << ref_output[i] << " GPU output: " << output[i]
-                      << std::endl;
-        }
         EXPECT_TRUE(miopen::range_distance(ref_output) == miopen::range_distance(output));
         EXPECT_TRUE(error < threshold * 10) << "Error output beyond tolerance Error:" << error
                                             << ",  Thresholdx10: " << threshold * 10;
 
         auto backprop_error = miopen::rms_range(ref_backprop, backprop);
-        for(int i = 0; i < backprop.data.size(); i++)
-        {
-            std::cout << "CPU backprop: " << ref_backprop[i] << " GPU backprop: " << backprop[i]
-                      << std::endl;
-        }
         EXPECT_TRUE(miopen::range_distance(ref_backprop) == miopen::range_distance(backprop));
         EXPECT_TRUE(backprop_error < threshold * 10)
             << "Error backprop beyond tolerance Error:" << backprop_error


### PR DESCRIPTION
* Added contiguous SoftmaxCrossEntropyWithLogits forward and backward operation and kernel.
* Added driver test and gtest for SoftmaxCrossEntropyWithLogits .
* New API is guarded by MIOPEN_BETA_API macro.
* Compared to ROCm pytorch: [Link](https://morehio-my.sharepoint.com/:x:/r/personal/kyeonghwan_ryu_moreh_io/_layouts/15/Doc.aspx?sourcedoc=%7B3E71B536-3742-4497-892A-F29002E7C2BC%7D&file=SoftmaxCrossEntropyWithLogits_benchmark.xlsx&action=default&mobileredirect=true&wdsle=0)


* Average over all cases:

|type    |Forward| Backward |
|--------|-------|-------|
|float16 | 3.01| 4.27 |
|float32 | 2.72| 2.99 | 
|bfloat16| 2.99| 4.43|