### PR TITLE
[MV-1329] [MV-MIOpen] Port ResourceApplyGradientDescent

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(MIOpenDriver
     dm_gemm.cpp
     dm_getitem.cpp
     dm_glu.cpp
+    dm_gradientdescent.cpp
     dm_groupnorm.cpp
     dm_kthvalue.cpp
     dm_layernorm.cpp

--- a/driver/dm_gradientdescent.cpp
+++ b/driver/dm_gradientdescent.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "registry_driver_maker.hpp"
+#include "gradientdescent_driver.hpp"
+
+static Driver* makeDriver(const std::string& base_arg)
+{
+    if(base_arg == "gradientdescent")
+        return new GradientDescentDriver<float, float>();
+    if(base_arg == "gradientdescentfp16")
+        return new GradientDescentDriver<float16, float>();
+    if(base_arg == "gradientdescentbfp16")
+        return new GradientDescentDriver<bfloat16, float>();
+    return nullptr;
+}
+
+REGISTER_DRIVER_MAKER(makeDriver);

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -177,7 +177,7 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
            "adamw[fp16], ampadamw, transformersadamw[fp16], transformersampadamw, "
            "getitem[bfp16|fp16], reducecalculation[bfp16|fp16], rope[bfp16|fp16], "
            "prelu[bfp16|fp16], kthvalue[bfp16|fp16], glu[bfp16|fp16], softmarginloss[bfp16|fp16], "
-           "multimarginloss[bfp16|fp16]\n");
+           "multimarginloss[bfp16|fp16], gradientdescent[bfp16|fp16]\n");
     exit(0); // NOLINT (concurrency-mt-unsafe)
 }
 
@@ -214,6 +214,7 @@ inline std::string ParseBaseArg(int argc, char* argv[])
        arg != "kthvaluebfp16" && arg != "glu" && arg != "glufp16" && arg != "glubfp16" &&
        arg != "softmarginloss" && arg != "softmarginlossfp16" && arg != "softmarginlossbfp16" &&
        arg != "multimarginloss" && arg != "multimarginlossfp16" && arg != "multimarginlossbfp16" &&
+       arg != "gradientdescent" && arg != "gradientdescentfp16" && arg != "gradientdescentbfp16" &&
        arg != "--version")
     {
         printf("FAILED: Invalid Base Input Argument\n");

--- a/driver/gradientdescent_driver.hpp
+++ b/driver/gradientdescent_driver.hpp
@@ -1,0 +1,388 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#pragma once
+
+#include <miopen/tensor.hpp>
+#include <miopen/tensor_view_utils.hpp>
+#include <../test/ford.hpp>
+
+#include "InputFlags.hpp"
+#include "driver.hpp"
+#include "random.hpp"
+#include "tensor_driver.hpp"
+#include "timer.hpp"
+
+#include <../test/tensor_holder.hpp>
+#include <../test/verify.hpp>
+
+#include <miopen/env.hpp>
+#include <miopen/handle.hpp>
+#include <miopen/miopen.h>
+#include <vector>
+
+template <typename Tgpu, typename Tcheck, typename Tseg>
+int32_t mloGradientDescentRunHost(const miopenTensorDescriptor_t varInDesc,
+                                  const miopenTensorDescriptor_t varOutDesc,
+                                  const miopenTensorDescriptor_t alphaInDesc,
+                                  const miopenTensorDescriptor_t deltaInDesc,
+                                  const Tgpu* var_in,
+                                  Tcheck* var_out,
+                                  const Tgpu* alpha_in,
+                                  const Tgpu* delta_in)
+{
+    auto var_in_tv   = miopen::get_inner_expanded_tv<5>(miopen::deref(varInDesc));
+    auto var_out_tv  = miopen::get_inner_expanded_tv<5>(miopen::deref(varOutDesc));
+    auto alpha_in_tv = miopen::get_inner_expanded_tv<1>(miopen::deref(alphaInDesc));
+    auto delta_in_tv = miopen::get_inner_expanded_tv<5>(miopen::deref(deltaInDesc));
+    uint64_t N       = miopen::deref(varInDesc).GetElementSize();
+
+    par_ford(N)([&](uint64_t gid) {
+        auto tensor_layout = tensor_layout_t<5>(var_in_tv, gid);
+        double var   = static_cast<double>(var_in[var_in_tv.get_tensor_view_idx(tensor_layout)]);
+        double alpha = static_cast<double>(alpha_in[alpha_in_tv.get_tensor_view_idx({0})]);
+        double delta =
+            static_cast<double>(delta_in[delta_in_tv.get_tensor_view_idx(tensor_layout)]);
+
+        var -= alpha * delta;
+
+        var_out[var_out_tv.get_tensor_view_idx(tensor_layout)] = static_cast<Tcheck>(var);
+    });
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref = Tgpu>
+class GradientDescentDriver : public Driver
+{
+public:
+    GradientDescentDriver() : Driver()
+    {
+        miopenCreateTensorDescriptor(&varInDesc);
+        miopenCreateTensorDescriptor(&varOutDesc);
+        miopenCreateTensorDescriptor(&alphaInDesc);
+        miopenCreateTensorDescriptor(&deltaInDesc);
+
+        data_type = miopen_type<Tgpu>{};
+    }
+
+    std::vector<int> ComputeStrides(std::vector<int> input);
+    int AddCmdLineArgs() override;
+    int ParseCmdLineArgs(int argc, char* argv[]) override;
+    InputFlags& GetInputFlags() override { return inflags; }
+
+    int GetandSetData() override;
+
+    int AllocateBuffersAndCopy() override;
+
+    int RunForwardGPU() override;
+    int RunForwardCPU();
+
+    int RunBackwardGPU() override;
+    int RunBackwardCPU();
+
+    Tref GetTolerance();
+    int VerifyBackward() override;
+    int VerifyForward() override;
+    ~GradientDescentDriver() override
+    {
+        miopenDestroyTensorDescriptor(varInDesc);
+        miopenDestroyTensorDescriptor(varOutDesc);
+        miopenDestroyTensorDescriptor(alphaInDesc);
+        miopenDestroyTensorDescriptor(deltaInDesc);
+    }
+
+private:
+    InputFlags inflags;
+
+    miopenTensorDescriptor_t varInDesc;
+    miopenTensorDescriptor_t varOutDesc;
+    miopenTensorDescriptor_t alphaInDesc;
+    miopenTensorDescriptor_t deltaInDesc;
+
+    std::unique_ptr<GPUMem> var_in_dev;
+    std::unique_ptr<GPUMem> var_out_dev;
+    std::unique_ptr<GPUMem> alpha_in_dev;
+    std::unique_ptr<GPUMem> delta_in_dev;
+
+    std::vector<Tgpu> var_in;
+    std::vector<Tgpu> var_out;
+    std::vector<Tgpu> var_out_init;
+    std::vector<Tgpu> alpha_in;
+    std::vector<Tgpu> delta_in;
+
+    std::vector<Tref> var_out_host;
+
+    bool isContiguous;
+};
+
+template <typename Tgpu, typename Tref>
+int GradientDescentDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
+{
+    inflags.Parse(argc, argv);
+    isContiguous = inflags.GetValueInt("is-contiguous") == 1 ? true : false;
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        miopenEnableProfiling(GetHandle(), true);
+    }
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int GradientDescentDriver<Tgpu, Tref>::GetandSetData()
+{
+    std::vector<int> input_dims = inflags.GetValueTensor("input_dims").lengths;
+    std::vector<int> alpha_dim  = {1};
+    std::vector<int> in_stride  = ComputeStrides(input_dims);
+
+    if(SetTensorNd(varInDesc, input_dims, data_type) != miopenStatusSuccess)
+        MIOPEN_THROW("Error parsing var_in tensor: " + inflags.GetValueStr("input_dims") + ".");
+    if(SetTensorNd(varOutDesc, input_dims, data_type) != miopenStatusSuccess)
+        MIOPEN_THROW("Error parsing var_out tensor: " + inflags.GetValueStr("input_dims") + ".");
+    if(SetTensorNd(alphaInDesc, alpha_dim, data_type) != miopenStatusSuccess)
+        MIOPEN_THROW("Error parsing alpha_in tensor: {1}.");
+    if(SetTensorNd(deltaInDesc, input_dims, data_type) != miopenStatusSuccess)
+        MIOPEN_THROW("Error parsing delta_in tensor: " + inflags.GetValueStr("input_dims") + ".");
+
+    return miopenStatusSuccess;
+}
+
+// Equivalent to: tensor.tranpose(0, -1).contiguous().tranpose(0, -1) incase contiguous = False
+template <typename Tgpu, typename Tref>
+std::vector<int> GradientDescentDriver<Tgpu, Tref>::ComputeStrides(std::vector<int> inputDim)
+{
+    if(!isContiguous)
+        std::swap(inputDim.front(), inputDim.back());
+    std::vector<int> strides(inputDim.size());
+    strides.back() = 1;
+    for(int i = inputDim.size() - 2; i >= 0; --i)
+        strides[i] = strides[i + 1] * inputDim[i + 1];
+    if(!isContiguous)
+        std::swap(strides.front(), strides.back());
+    return strides;
+}
+
+template <typename Tgpu, typename Tref>
+int GradientDescentDriver<Tgpu, Tref>::AddCmdLineArgs()
+{
+    inflags.AddInputFlag("forw", 'F', "1", "Run only Forward GradientDescent (Default=1)", "int");
+    inflags.AddTensorFlag(
+        "input_dims",
+        'd',
+        "2x3x7x50x10",
+        "The dimensional lengths of the input tensor: N,C,D,H Example: 2x3x7x50x10.");
+
+    inflags.AddInputFlag("is-contiguous", 'C', "1", "is-contiguous (Default=1)", "int");
+    inflags.AddInputFlag("iter", 'i', "10", "Number of Iterations (Default=10)", "int");
+    inflags.AddInputFlag("verify", 'V', "1", "Verify Each Layer (Default=1)", "int");
+    inflags.AddInputFlag("time", 't', "1", "Time Each Layer (Default=1)", "int");
+    inflags.AddInputFlag(
+        "wall", 'w', "0", "Wall-clock Time Each Layer, Requires time == 1 (Default=0)", "int");
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int GradientDescentDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
+{
+    size_t element_size = miopen::deref(varInDesc).GetElementSize();
+
+    uint32_t ctx = 0;
+
+    var_in_dev   = std::unique_ptr<GPUMem>(new GPUMem(ctx, element_size, sizeof(Tgpu)));
+    var_out_dev  = std::unique_ptr<GPUMem>(new GPUMem(ctx, element_size, sizeof(Tgpu)));
+    alpha_in_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, 1, sizeof(Tgpu)));
+    delta_in_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, element_size, sizeof(Tgpu)));
+
+    var_in       = std::vector<Tgpu>(element_size, static_cast<Tgpu>(0));
+    var_out      = std::vector<Tgpu>(element_size, static_cast<Tgpu>(0));
+    var_out_init = std::vector<Tgpu>(element_size, static_cast<Tgpu>(0));
+    alpha_in     = std::vector<Tgpu>(1, static_cast<Tgpu>(0));
+    delta_in     = std::vector<Tgpu>(element_size, static_cast<Tgpu>(0));
+
+    var_out_host = std::vector<Tref>(element_size, static_cast<Tref>(0));
+
+    for(int i = 0; i < element_size; i++)
+    {
+        var_in[i] = prng::gen_A_to_B<Tgpu>(static_cast<Tgpu>(0.0), static_cast<Tgpu>(1.0));
+    }
+    for(int i = 0; i < element_size; i++)
+    {
+        delta_in[i] = prng::gen_A_to_B<Tgpu>(static_cast<Tgpu>(0.0), static_cast<Tgpu>(1.0));
+    }
+    for(int i = 0; i < 1; i++)
+    {
+        alpha_in[i] = prng::gen_A_to_B<Tgpu>(static_cast<Tgpu>(0.0), static_cast<Tgpu>(1.0));
+    }
+
+    if(var_in_dev->ToGPU(GetStream(), var_in.data()) != 0)
+    {
+        std::cerr << "Error copying var_in to GPU, size: " << var_in_dev->GetSize() << std::endl;
+        return miopenStatusInternalError;
+    }
+    if(var_out_dev->ToGPU(GetStream(), var_out.data()) != 0)
+    {
+        std::cerr << "Error copying var_out to GPU, size: " << var_out_dev->GetSize() << std::endl;
+        return miopenStatusInternalError;
+    }
+    if(alpha_in_dev->ToGPU(GetStream(), alpha_in.data()) != 0)
+    {
+        std::cerr << "Error copying alpha_in to GPU, size: " << alpha_in_dev->GetSize()
+                  << std::endl;
+        return miopenStatusInternalError;
+    }
+    if(delta_in_dev->ToGPU(GetStream(), delta_in.data()) != 0)
+    {
+        std::cerr << "Error copying delta_in to GPU, size: " << delta_in_dev->GetSize()
+                  << std::endl;
+        return miopenStatusInternalError;
+    }
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int GradientDescentDriver<Tgpu, Tref>::RunForwardGPU()
+{
+    float kernel_total_time = 0;
+    float kernel_first_time = 0;
+
+    Timer t;
+    START_TIME
+
+    for(int i = 0; i < inflags.GetValueInt("iter"); i++)
+    {
+        if(var_out_dev->ToGPU(GetStream(), var_out_init.data()) != 0)
+        {
+            std::cerr << "Error copying var_out to GPU, size: " << var_out_dev->GetSize()
+                      << std::endl;
+            return miopenStatusInternalError;
+        }
+        auto status = miopenGradientDescent(GetHandle(),
+                                            varInDesc,
+                                            var_in_dev->GetMem(),
+                                            varOutDesc,
+                                            var_out_dev->GetMem(),
+                                            alphaInDesc,
+                                            alpha_in_dev->GetMem(),
+                                            deltaInDesc,
+                                            delta_in_dev->GetMem());
+        MIOPEN_THROW_IF(status != miopenStatusSuccess, "Error in miopenGradientDescent");
+
+        float time = 0.0;
+        miopenGetKernelTime(GetHandle(), &time);
+        kernel_total_time += time;
+        if(i == 0)
+            kernel_first_time = time;
+    }
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        STOP_TIME
+        int iter = inflags.GetValueInt("iter");
+        if(WALL_CLOCK)
+            std::cout << "Wall-clock Time Forward GradientDescent Elapsed: "
+                      << t.gettime_ms() / iter << " ms\n";
+
+        float kernel_average_time =
+            iter > 1 ? (kernel_total_time - kernel_first_time) / (iter - 1) : kernel_first_time;
+        std::cout << "GPU Kernel Time Forward GradientDescent Elapsed: " << kernel_average_time
+                  << " ms\n";
+    }
+
+    if(var_out_dev->FromGPU(GetStream(), var_out.data()) != 0)
+    {
+        std::cerr << "Error copying var_out_dev from GPU, size: " << var_out_dev->GetSize()
+                  << std::endl;
+        return miopenStatusInternalError;
+    }
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int GradientDescentDriver<Tgpu, Tref>::RunForwardCPU()
+{
+    int status = miopenStatusSuccess;
+
+    status = mloGradientDescentRunHost<Tgpu, Tref, int>(varInDesc,
+                                                        varOutDesc,
+                                                        alphaInDesc,
+                                                        deltaInDesc,
+                                                        var_in.data(),
+                                                        var_out_host.data(),
+                                                        alpha_in.data(),
+                                                        delta_in.data());
+    MIOPEN_THROW_IF(status != miopenStatusSuccess, "Error in mloGradientDescentRunHost");
+
+    return status;
+}
+
+template <typename Tgpu, typename Tref>
+int GradientDescentDriver<Tgpu, Tref>::RunBackwardGPU()
+{
+    return miopenStatusNotImplemented;
+}
+
+template <typename Tgpu, typename Tref>
+int GradientDescentDriver<Tgpu, Tref>::RunBackwardCPU()
+{
+    return miopenStatusNotImplemented;
+}
+
+template <typename Tgpu, typename Tref>
+Tref GradientDescentDriver<Tgpu, Tref>::GetTolerance()
+{
+    Tref tolerance = std::numeric_limits<Tgpu>::epsilon() * 10;
+    return tolerance;
+}
+
+template <typename Tgpu, typename Tref>
+int GradientDescentDriver<Tgpu, Tref>::VerifyForward()
+{
+    RunForwardCPU();
+    const Tref tolerance = GetTolerance();
+    auto error           = miopen::rms_range(var_out_host, var_out);
+
+    if(!std::isfinite(error) || error > tolerance)
+    {
+        std::cout << "Forward GradientDescent Verifies FAILED: " << error << " > " << tolerance
+                  << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        std::cout << "Forward GradientDescent Verifies OK on CPU reference (err=" << error << ")"
+                  << std::endl;
+    }
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int GradientDescentDriver<Tgpu, Tref>::VerifyBackward()
+{
+    return miopenStatusNotImplemented;
+}

--- a/driver/gradientdescent_driver.hpp
+++ b/driver/gradientdescent_driver.hpp
@@ -43,10 +43,9 @@
 #include <miopen/miopen.h>
 #include <vector>
 
-template <typename Tgpu, typename Tcheck, typename Tseg>
+template <typename Tgpu, typename Tcheck>
 int32_t mloGradientDescentRunHost(const miopenTensorDescriptor_t varInDesc,
                                   const miopenTensorDescriptor_t varOutDesc,
-                                  const miopenTensorDescriptor_t alphaInDesc,
                                   const miopenTensorDescriptor_t deltaInDesc,
                                   const Tgpu* var_in,
                                   Tcheck* var_out,
@@ -55,14 +54,13 @@ int32_t mloGradientDescentRunHost(const miopenTensorDescriptor_t varInDesc,
 {
     auto var_in_tv   = miopen::get_inner_expanded_tv<5>(miopen::deref(varInDesc));
     auto var_out_tv  = miopen::get_inner_expanded_tv<5>(miopen::deref(varOutDesc));
-    auto alpha_in_tv = miopen::get_inner_expanded_tv<1>(miopen::deref(alphaInDesc));
     auto delta_in_tv = miopen::get_inner_expanded_tv<5>(miopen::deref(deltaInDesc));
     uint64_t N       = miopen::deref(varInDesc).GetElementSize();
 
     par_ford(N)([&](uint64_t gid) {
         auto tensor_layout = tensor_layout_t<5>(var_in_tv, gid);
         double var   = static_cast<double>(var_in[var_in_tv.get_tensor_view_idx(tensor_layout)]);
-        double alpha = static_cast<double>(alpha_in[alpha_in_tv.get_tensor_view_idx({0})]);
+        double alpha = static_cast<double>(alpha_in[0]);
         double delta =
             static_cast<double>(delta_in[delta_in_tv.get_tensor_view_idx(tensor_layout)]);
 
@@ -327,14 +325,13 @@ int GradientDescentDriver<Tgpu, Tref>::RunForwardCPU()
 {
     int status = miopenStatusSuccess;
 
-    status = mloGradientDescentRunHost<Tgpu, Tref, int>(varInDesc,
-                                                        varOutDesc,
-                                                        alphaInDesc,
-                                                        deltaInDesc,
-                                                        var_in.data(),
-                                                        var_out_host.data(),
-                                                        alpha_in.data(),
-                                                        delta_in.data());
+    status = mloGradientDescentRunHost<Tgpu, Tref>(varInDesc,
+                                                   varOutDesc,
+                                                   deltaInDesc,
+                                                   var_in.data(),
+                                                   var_out_host.data(),
+                                                   alpha_in.data(),
+                                                   delta_in.data());
     MIOPEN_THROW_IF(status != miopenStatusSuccess, "Error in mloGradientDescentRunHost");
 
     return status;

--- a/driver/gradientdescent_driver.hpp
+++ b/driver/gradientdescent_driver.hpp
@@ -374,8 +374,8 @@ int GradientDescentDriver<Tgpu, Tref>::VerifyForward()
     }
     else
     {
-        std::cout << "Forward GradientDescent Verifies OK on CPU reference (err=" << error << ")"
-                  << std::endl;
+        std::cout << "Forward GradientDescent Verifies OK on CPU reference (err=" << error << " < "
+                  << tolerance << ')' << std::endl;
     }
 
     return miopenStatusSuccess;

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -8003,6 +8003,40 @@ MIOPEN_EXPORT miopenStatus_t miopenMultiMarginLossForward(miopenHandle_t handle,
 // CLOSEOUT LossFunction DOXYGEN GROUP
 #endif // MIOPEN_BETA_API
 
+#ifdef MIOPEN_BETA_API
+// gradientdescent APIs
+/** @addtogroup SGD
+ *
+ * @{
+ */
+/*! @brief Execute a gradientdescent layer
+ *
+ * @param handle                   MIOpen handle (input)
+ * @param varInDesc                Tensor descriptor for the input variable tensor (input)
+ * @param var_in                   Input variable tensor (input)
+ * @param varOutDesc               Tensor descriptor for the output variable tensor (input)
+ * @param var_out                  Output variable tensor (output)
+ * @param alphaInDesc              Tensor descriptor for the input alpha tensor (input)
+ * @param alpha_in                 Input alpha tensor (input)
+ * @param deltaInDesc              Tensor descriptor for the input delta tensor (input)
+ * @param delta_in                 Input delta tensor (input)
+ * @return                         miopenStatus_t
+ */
+
+MIOPEN_EXPORT miopenStatus_t miopenGradientDescent(miopenHandle_t handle,
+                                                   const miopenTensorDescriptor_t varInDesc,
+                                                   const void* var_in,
+                                                   const miopenTensorDescriptor_t varOutDesc,
+                                                   void* var_out,
+                                                   const miopenTensorDescriptor_t alphaInDesc,
+                                                   const void* alpha_in,
+                                                   const miopenTensorDescriptor_t deltaInDesc,
+                                                   const void* delta_in);
+
+/** @} */
+// CLOSEOUT SGD DOXYGEN GROUP
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,11 +126,12 @@ set( MIOpen_Source
     fusion.cpp
     fusion/problem_description.cpp
     generic_search.cpp
+    getitem/problem_description.cpp
     getitem_api.cpp
     glu/problem_description.cpp
     glu_api.cpp
-    gradientdescent_api.cpp
     gradientdescent/problem_description.cpp
+    gradientdescent_api.cpp
     graphapi/convolution.cpp
     graphapi/conv_bias_res_add_activ_forward_executor.cpp
     graphapi/engine.cpp
@@ -147,11 +148,10 @@ set( MIOpen_Source
     graphapi/rng.cpp
     graphapi/tensor.cpp
     graphapi/variant_pack.cpp
-    groupnorm_api.cpp
     groupnorm/problem_description.cpp
+    groupnorm_api.cpp
     handle_api.cpp
     invoker_cache.cpp
-    getitem/problem_description.cpp
     kernel_build_params.cpp
     kernel_warnings.cpp
     kthvalue/problem_description.cpp
@@ -302,11 +302,11 @@ set( MIOpen_Source
     solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
     solver/conv_ocl_dir2Dfwd_fused.cpp
     solver/conv_winoRxS_fused.cpp
+    solver/getitem/backward_getitem.cpp
     solver/glu/backward_glu.cpp
     solver/glu/forward_glu.cpp
     solver/gradientdescent/gradientdescent.cpp
     solver/groupnorm/forward_groupnorm.cpp
-    solver/getitem/backward_getitem.cpp
     solver/kthvalue/forward_kthvalue.cpp
     solver/layernorm/backward_t5layernorm.cpp
     solver/layernorm/forward_addlayernorm.cpp
@@ -671,10 +671,10 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         addlayernorm.cpp
         cat.cpp
         exec_utils.cpp
-        groupnorm.cpp
         getitem.cpp
         glu.cpp
         gradientdescent.cpp
+        groupnorm.cpp
         kernel_cache.cpp
         kthvalue.cpp
         layernorm.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,6 +129,8 @@ set( MIOpen_Source
     getitem_api.cpp
     glu/problem_description.cpp
     glu_api.cpp
+    gradientdescent_api.cpp
+    gradientdescent/problem_description.cpp
     graphapi/convolution.cpp
     graphapi/conv_bias_res_add_activ_forward_executor.cpp
     graphapi/engine.cpp
@@ -304,6 +306,7 @@ set( MIOpen_Source
     solver/glu/forward_glu.cpp
     solver/groupnorm/forward_groupnorm.cpp
     solver/getitem/backward_getitem.cpp
+    solver/gradientdescent/gradientdescent.cpp
     solver/kthvalue/forward_kthvalue.cpp
     solver/layernorm/backward_t5layernorm.cpp
     solver/layernorm/forward_addlayernorm.cpp
@@ -529,6 +532,7 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         kernels/MIOpenConvDirBatchNormActiv.cl
         kernels/MIOpenConvDirGenFwd.cl
         kernels/MIOpenGLU.cpp
+        kernels/MIOpenGradientDescent.cpp
         kernels/MIOpenGroupNorm.cpp
         kernels/MIOpenGetitem.cpp
         kernels/MIOpenKthvalue.cpp
@@ -670,6 +674,7 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         groupnorm.cpp
         getitem.cpp
         glu.cpp
+        gradientdescent.cpp
         kernel_cache.cpp
         kthvalue.cpp
         layernorm.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -304,9 +304,9 @@ set( MIOpen_Source
     solver/conv_winoRxS_fused.cpp
     solver/glu/backward_glu.cpp
     solver/glu/forward_glu.cpp
+    solver/gradientdescent/gradientdescent.cpp
     solver/groupnorm/forward_groupnorm.cpp
     solver/getitem/backward_getitem.cpp
-    solver/gradientdescent/gradientdescent.cpp
     solver/kthvalue/forward_kthvalue.cpp
     solver/layernorm/backward_t5layernorm.cpp
     solver/layernorm/forward_addlayernorm.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -531,10 +531,10 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         kernels/MIOpenConvDirUni.cl
         kernels/MIOpenConvDirBatchNormActiv.cl
         kernels/MIOpenConvDirGenFwd.cl
+        kernels/MIOpenGetitem.cpp
         kernels/MIOpenGLU.cpp
         kernels/MIOpenGradientDescent.cpp
         kernels/MIOpenGroupNorm.cpp
-        kernels/MIOpenGetitem.cpp
         kernels/MIOpenKthvalue.cpp
         kernels/MIOpenLayerNorm.cpp
         kernels/MIOpenLRNBwd.cl

--- a/src/gradientdescent.cpp
+++ b/src/gradientdescent.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include <miopen/gradientdescent.hpp>
+#include <miopen/kernel_cache.hpp>
+#include <miopen/float_equal.hpp>
+#include <miopen/tensor.hpp>
+#include <miopen/gradientdescent/invoke_params.hpp>
+#include <miopen/gradientdescent/solvers.hpp>
+#include <miopen/find_solution.hpp>
+
+namespace miopen {
+
+namespace GradientDescent {
+
+miopenStatus_t GradientDescent(Handle& handle,
+                               const TensorDescriptor& varInDesc,
+                               ConstData_t var_in,
+                               const TensorDescriptor& varOutDesc,
+                               Data_t var_out,
+                               const TensorDescriptor& alphaInDesc,
+                               ConstData_t alpha_in,
+                               const TensorDescriptor& deltaInDesc,
+                               ConstData_t delta_in)
+{
+    const auto problem =
+        GradientDescent::ProblemDescription{varInDesc, varOutDesc, alphaInDesc, deltaInDesc};
+
+    const auto invoke_params = [&]() {
+        auto tmp        = GradientDescent::InvokeParams{};
+        tmp.varInDesc   = &varInDesc;
+        tmp.varOutDesc  = &varOutDesc;
+        tmp.alphaInDesc = &alphaInDesc;
+        tmp.deltaInDesc = &deltaInDesc;
+
+        tmp.var_in   = var_in;
+        tmp.var_out  = var_out;
+        tmp.alpha_in = alpha_in;
+        tmp.delta_in = delta_in;
+
+        return tmp;
+    }();
+
+    const auto algo    = AlgorithmName{"GradientDescent"};
+    const auto solvers = solver::SolverContainer<solver::GradientDescent::GradientDescent>{};
+    solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
+
+    return miopenStatusSuccess;
+}
+
+} // namespace GradientDescent
+
+} // namespace miopen

--- a/src/gradientdescent/problem_description.cpp
+++ b/src/gradientdescent/problem_description.cpp
@@ -43,7 +43,7 @@ NetworkConfig ProblemDescription::MakeNetworkConfig() const
     ss << "input_lengths";
     for(auto length : input_lengths)
         ss << length << ',';
-    ss << "is_contiguous" << IsAllContiguous();
+    ss << "is_allpacked_samestride" << IsAllPackedSameStride();
 
     return NetworkConfig{ss.str()};
 }

--- a/src/gradientdescent/problem_description.cpp
+++ b/src/gradientdescent/problem_description.cpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/gradientdescent/problem_description.hpp>
+#include <miopen/names.hpp>
+
+#include <sstream>
+
+namespace miopen {
+
+namespace GradientDescent {
+
+NetworkConfig ProblemDescription::MakeNetworkConfig() const
+{
+    auto dtype         = varInDesc.GetType();
+    auto input_lengths = varInDesc.GetLengths();
+
+    std::ostringstream ss;
+    ss << "dtype" << dtype;
+    ss << "input_lengths";
+    for(auto length : input_lengths)
+        ss << length << ',';
+    ss << "is_contiguous" << IsAllContiguous();
+
+    return NetworkConfig{ss.str()};
+}
+
+} // namespace GradientDescent
+
+} // namespace miopen

--- a/src/gradientdescent_api.cpp
+++ b/src/gradientdescent_api.cpp
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include <miopen/gradientdescent.hpp>
+#include <miopen/errors.hpp>
+#include <miopen/handle.hpp>
+#include <miopen/logger.hpp>
+#include <miopen/tensor_ops.hpp>
+
+inline std::ostream& operator<<(std::ostream& os, const std::vector<size_t>& v)
+{
+    os << '{';
+    for(int i = 0; i < v.size(); ++i)
+    {
+        if(i != 0)
+            os << ',';
+        os << v[i];
+    }
+    os << '}';
+    return os;
+}
+
+inline void LogCmdGradientDescent(const miopenTensorDescriptor_t& InputDesc)
+{
+    if(miopen::IsLoggingCmd())
+    {
+        std::stringstream ss;
+        auto dtype = miopen::deref(InputDesc).GetType();
+        if(dtype == miopenHalf)
+        {
+            ss << "gradientdescentfp16";
+        }
+        else if(dtype == miopenFloat)
+        {
+            ss << "gradientdescentfp32";
+        }
+        else if(dtype == miopenBFloat16)
+        {
+            ss << "gradientdescentbf16";
+        }
+        ss << " -in_dims " << miopen::deref(InputDesc).GetLengths();
+        MIOPEN_LOG_DRIVER_CMD(ss.str());
+    }
+}
+
+extern "C" miopenStatus_t miopenGradientDescent(miopenHandle_t handle,
+                                                const miopenTensorDescriptor_t varInDesc,
+                                                const void* var_in,
+                                                const miopenTensorDescriptor_t varOutDesc,
+                                                void* var_out,
+                                                const miopenTensorDescriptor_t alphaInDesc,
+                                                const void* alpha_in,
+                                                const miopenTensorDescriptor_t deltaInDesc,
+                                                const void* delta_in)
+
+{
+    MIOPEN_LOG_FUNCTION(handle,
+                        varInDesc,
+                        var_in,
+                        varOutDesc,
+                        var_out,
+                        alphaInDesc,
+                        alpha_in,
+                        deltaInDesc,
+                        delta_in);
+    LogCmdGradientDescent(varInDesc);
+    return miopen::try_([&] {
+        miopen::GradientDescent::GradientDescent(miopen::deref(handle),
+                                                 miopen::deref(varInDesc),
+                                                 DataCast(var_in),
+                                                 miopen::deref(varOutDesc),
+                                                 DataCast(var_out),
+                                                 miopen::deref(alphaInDesc),
+                                                 DataCast(alpha_in),
+                                                 miopen::deref(deltaInDesc),
+                                                 DataCast(delta_in));
+    });
+}

--- a/src/include/miopen/gradientdescent.hpp
+++ b/src/include/miopen/gradientdescent.hpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#pragma once
+#include <miopen/common.hpp>
+
+namespace miopen {
+
+struct Handle;
+struct TensorDescriptor;
+
+namespace GradientDescent {
+
+MIOPEN_INTERNALS_EXPORT miopenStatus_t GradientDescent(Handle& handle,
+                                                       const TensorDescriptor& varInDesc,
+                                                       ConstData_t var_in,
+                                                       const TensorDescriptor& varOutDesc,
+                                                       Data_t var_out,
+                                                       const TensorDescriptor& alphaInDesc,
+                                                       ConstData_t alpha_in,
+                                                       const TensorDescriptor& deltaInDesc,
+                                                       ConstData_t delta_in);
+
+} // namespace GradientDescent
+
+} // namespace miopen

--- a/src/include/miopen/gradientdescent/invoke_params.hpp
+++ b/src/include/miopen/gradientdescent/invoke_params.hpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include <miopen/invoke_params.hpp>
+#include <miopen/tensor.hpp>
+
+namespace miopen {
+
+namespace GradientDescent {
+
+struct InvokeParams : public miopen::InvokeParams
+{
+    InvokeParams() = default;
+
+    const TensorDescriptor* varInDesc   = nullptr;
+    const TensorDescriptor* varOutDesc  = nullptr;
+    const TensorDescriptor* alphaInDesc = nullptr;
+    const TensorDescriptor* deltaInDesc = nullptr;
+
+    ConstData_t var_in   = nullptr;
+    Data_t var_out       = nullptr;
+    ConstData_t alpha_in = nullptr;
+    ConstData_t delta_in = nullptr;
+
+    std::size_t GetWorkspaceSize() const { return 0; }
+    Data_t GetWorkspace() const { return nullptr; }
+};
+
+} // namespace GradientDescent
+
+} // namespace miopen

--- a/src/include/miopen/gradientdescent/problem_description.hpp
+++ b/src/include/miopen/gradientdescent/problem_description.hpp
@@ -76,9 +76,11 @@ struct ProblemDescription : ProblemDescriptionBase
         return true;
     }
 
-    bool IsAllContiguous() const
+    bool IsAllPackedSameStride() const
     {
-        return varInDesc.IsContiguous() && varOutDesc.IsContiguous() && deltaInDesc.IsContiguous();
+        return varInDesc.IsPacked() && varOutDesc.IsPacked() && deltaInDesc.IsPacked() &&
+               varInDesc.GetStrides() == varOutDesc.GetStrides() &&
+               varInDesc.GetStrides() == deltaInDesc.GetStrides();
     }
     NetworkConfig MakeNetworkConfig() const override;
 

--- a/src/include/miopen/gradientdescent/problem_description.hpp
+++ b/src/include/miopen/gradientdescent/problem_description.hpp
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include <miopen/activ.hpp>
+#include <miopen/problem_description_base.hpp>
+#include <miopen/tensor.hpp>
+
+namespace miopen {
+
+struct NetworkConfig;
+
+namespace GradientDescent {
+
+struct ProblemDescription : ProblemDescriptionBase
+{
+    ProblemDescription(const TensorDescriptor& varInDesc_,
+                       const TensorDescriptor& varOutDesc_,
+                       const TensorDescriptor& alphaInDesc_,
+                       const TensorDescriptor& deltaInDesc_)
+        : varInDesc(varInDesc_),
+          varOutDesc(varOutDesc_),
+          alphaInDesc(alphaInDesc_),
+          deltaInDesc(deltaInDesc_)
+    {
+        IsSameType();
+        IsSameDims();
+    }
+
+    const TensorDescriptor& GetvarInDesc() const { return varInDesc; }
+    const TensorDescriptor& GetvarOutDesc() const { return varOutDesc; }
+    const TensorDescriptor& GetalphaInDesc() const { return alphaInDesc; }
+
+    bool IsSameType() const
+    {
+        if(varInDesc.GetType() != varOutDesc.GetType() ||
+           varInDesc.GetType() != alphaInDesc.GetType() ||
+           varInDesc.GetType() != deltaInDesc.GetType())
+        {
+            MIOPEN_THROW(miopenStatusBadParm, "GradientDescent: Tensor types do not match.");
+        }
+        return true;
+    }
+
+    bool IsSameDims() const
+    {
+        if(varInDesc.GetLengths() != varOutDesc.GetLengths() ||
+           varInDesc.GetLengths() != deltaInDesc.GetLengths())
+        {
+            MIOPEN_THROW(miopenStatusBadParm, "GradientDescent: Tensor dimensions do not match.");
+        }
+        return true;
+    }
+
+    bool IsAllContiguous() const
+    {
+        return varInDesc.IsContiguous() && varOutDesc.IsContiguous() && deltaInDesc.IsContiguous();
+    }
+    NetworkConfig MakeNetworkConfig() const override;
+
+private:
+    TensorDescriptor varInDesc;
+    TensorDescriptor varOutDesc;
+    TensorDescriptor alphaInDesc;
+    TensorDescriptor deltaInDesc;
+};
+
+} // namespace GradientDescent
+
+} // namespace miopen

--- a/src/include/miopen/gradientdescent/solvers.hpp
+++ b/src/include/miopen/gradientdescent/solvers.hpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#pragma once
+
+#include <miopen/solver.hpp>
+#include <miopen/gradientdescent/problem_description.hpp>
+
+namespace miopen {
+
+namespace solver {
+
+namespace GradientDescent {
+
+using GradientDescentSolver =
+    NonTunableSolverBase<ExecutionContext, miopen::GradientDescent::ProblemDescription>;
+
+struct GradientDescent final : GradientDescentSolver
+{
+    const std::string& SolverDbId() const override { return GetSolverDbId<GradientDescent>(); }
+    bool IsApplicable(const ExecutionContext& context,
+                      const miopen::GradientDescent::ProblemDescription& problem) const override;
+    ConvSolution
+    GetSolution(const ExecutionContext& context,
+                const miopen::GradientDescent::ProblemDescription& problem) const override;
+};
+
+} // namespace GradientDescent
+
+} // namespace solver
+
+} // namespace miopen

--- a/src/include/miopen/solver_id.hpp
+++ b/src/include/miopen/solver_id.hpp
@@ -63,7 +63,8 @@ enum class Primitive
     ReLU,
     Kthvalue,
     SoftMarginLoss,
-    MultiMarginLoss
+    MultiMarginLoss,
+    GradientDescent,
 };
 
 struct MIOPEN_INTERNALS_EXPORT Id

--- a/src/kernels/MIOpenGradientDescent.cpp
+++ b/src/kernels/MIOpenGradientDescent.cpp
@@ -39,7 +39,6 @@ __device__ void resourceApplyGradientDescent(const TIO* __restrict__ var_in,
                                              const uint64_t input_size,
                                              tensor_view_t<5> var_in_tv,
                                              tensor_view_t<5> var_out_tv,
-                                             tensor_view_t<1> alpha_in_tv,
                                              tensor_view_t<5> delta_in_tv)
 {
     const uint64_t gid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -48,7 +47,7 @@ __device__ void resourceApplyGradientDescent(const TIO* __restrict__ var_in,
     auto tensor_layout = tensor_layout_t<5>(var_in_tv, gid);
 
     FLOAT_ACCUM var   = CVT_FLOAT2ACCUM(var_in[var_in_tv.get_tensor_view_idx(tensor_layout)]);
-    FLOAT_ACCUM alpha = CVT_FLOAT2ACCUM(alpha_in[alpha_in_tv.get_tensor_view_idx({0})]);
+    FLOAT_ACCUM alpha = CVT_FLOAT2ACCUM(alpha_in[0]);
     FLOAT_ACCUM delta = CVT_FLOAT2ACCUM(delta_in[delta_in_tv.get_tensor_view_idx(tensor_layout)]);
 
     var -= alpha * delta;
@@ -63,18 +62,10 @@ extern "C" __global__ void ResourceApplyGradientDescent(const D_TYPE* __restrict
                                                         const uint64_t input_size,
                                                         tensor_view_t<5> var_in_tv,
                                                         tensor_view_t<5> var_out_tv,
-                                                        tensor_view_t<1> alpha_in_tv,
                                                         tensor_view_t<5> delta_in_tv)
 {
-    resourceApplyGradientDescent<D_TYPE>(var_in,
-                                         var_out,
-                                         alpha_in,
-                                         delta_in,
-                                         input_size,
-                                         var_in_tv,
-                                         var_out_tv,
-                                         alpha_in_tv,
-                                         delta_in_tv);
+    resourceApplyGradientDescent<D_TYPE>(
+        var_in, var_out, alpha_in, delta_in, input_size, var_in_tv, var_out_tv, delta_in_tv);
 }
 
 template <typename TIO>

--- a/src/kernels/MIOpenGradientDescent.cpp
+++ b/src/kernels/MIOpenGradientDescent.cpp
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#endif
+
+#include "float_types.h"
+#include "tensor_view.hpp"
+
+template <typename TIO>
+__device__ void resourceApplyGradientDescent(const TIO* __restrict__ var_in,
+                                             TIO* __restrict__ var_out,
+                                             const TIO* __restrict__ alpha_in,
+                                             const TIO* __restrict__ delta_in,
+                                             const uint64_t input_size,
+                                             tensor_view_t<5> var_in_tv,
+                                             tensor_view_t<5> var_out_tv,
+                                             tensor_view_t<1> alpha_in_tv,
+                                             tensor_view_t<5> delta_in_tv)
+{
+    const uint64_t gid = threadIdx.x + blockIdx.x * blockDim.x;
+    if(gid >= input_size)
+        return;
+    auto tensor_layout = tensor_layout_t<5>(var_in_tv, gid);
+
+    FLOAT_ACCUM var   = CVT_FLOAT2ACCUM(var_in[var_in_tv.get_tensor_view_idx(tensor_layout)]);
+    FLOAT_ACCUM alpha = CVT_FLOAT2ACCUM(alpha_in[alpha_in_tv.get_tensor_view_idx({0})]);
+    FLOAT_ACCUM delta = CVT_FLOAT2ACCUM(delta_in[delta_in_tv.get_tensor_view_idx(tensor_layout)]);
+
+    var -= alpha * delta;
+
+    var_out[var_out_tv.get_tensor_view_idx(tensor_layout)] = CVT_ACCUM2FLOAT(var);
+}
+
+extern "C" __global__ void ResourceApplyGradientDescent(const D_TYPE* __restrict__ var_in,
+                                                        D_TYPE* __restrict__ var_out,
+                                                        const D_TYPE* __restrict__ alpha_in,
+                                                        const D_TYPE* __restrict__ delta_in,
+                                                        const uint64_t input_size,
+                                                        tensor_view_t<5> var_in_tv,
+                                                        tensor_view_t<5> var_out_tv,
+                                                        tensor_view_t<1> alpha_in_tv,
+                                                        tensor_view_t<5> delta_in_tv)
+{
+    resourceApplyGradientDescent<D_TYPE>(var_in,
+                                         var_out,
+                                         alpha_in,
+                                         delta_in,
+                                         input_size,
+                                         var_in_tv,
+                                         var_out_tv,
+                                         alpha_in_tv,
+                                         delta_in_tv);
+}
+
+template <typename TIO>
+__device__ void resourceApplyGradientDescentContiguous(const TIO* __restrict__ var_in,
+                                                       TIO* __restrict__ var_out,
+                                                       const TIO* __restrict__ alpha_in,
+                                                       const TIO* __restrict__ delta_in,
+                                                       const uint64_t input_size)
+{
+    const uint64_t gid = threadIdx.x + blockIdx.x * blockDim.x;
+    if(gid >= input_size)
+        return;
+
+    FLOAT_ACCUM var   = CVT_FLOAT2ACCUM(var_in[gid]);
+    FLOAT_ACCUM alpha = CVT_FLOAT2ACCUM(alpha_in[0]);
+    FLOAT_ACCUM delta = CVT_FLOAT2ACCUM(delta_in[gid]);
+
+    var -= alpha * delta;
+
+    var_out[gid] = CVT_ACCUM2FLOAT(var);
+}
+
+extern "C" __global__ void
+ResourceApplyGradientDescentContiguous(const D_TYPE* __restrict__ var_in,
+                                       D_TYPE* __restrict__ var_out,
+                                       const D_TYPE* __restrict__ alpha_in,
+                                       const D_TYPE* __restrict__ delta_in,
+                                       const uint64_t input_size)
+{
+    resourceApplyGradientDescentContiguous<D_TYPE>(var_in, var_out, alpha_in, delta_in, input_size);
+}

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -33,6 +33,7 @@
 #include <miopen/glu/solvers.hpp>
 #include <miopen/groupnorm/solvers.hpp>
 #include <miopen/getitem/solvers.hpp>
+#include <miopen/gradientdescent/solvers.hpp>
 #include <miopen/kthvalue/solvers.hpp>
 #include <miopen/layernorm/solvers.hpp>
 #include <miopen/pooling/solvers.hpp>
@@ -700,6 +701,10 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
              Primitive::MultiMarginLoss,
              multimarginloss::MultiMarginLossForward{}.SolverDbId());
 
+    Register(registry,
+             ++id,
+             Primitive::GradientDescent,
+             GradientDescent::GradientDescent{}.SolverDbId());
     // IMPORTANT: New solvers should be added to the end of the function!
 }
 

--- a/src/solver/gradientdescent/gradientdescent.cpp
+++ b/src/solver/gradientdescent/gradientdescent.cpp
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include <miopen/conv_solution.hpp>
+#include <miopen/execution_context.hpp>
+#include <miopen/invoke_params.hpp>
+#include <miopen/tensor_view_utils.hpp>
+#include <miopen/gradientdescent/solvers.hpp>
+
+#include <miopen/gradientdescent/invoke_params.hpp>
+#include <miopen/datatype.hpp>
+#include <miopen/mlo_internal.hpp>
+#include <miopen/gradientdescent.hpp>
+#include <miopen/target_properties.hpp>
+
+#define LOCAL_SIZE 256
+
+namespace miopen {
+
+namespace solver {
+
+namespace GradientDescent {
+
+bool GradientDescent::IsApplicable([[maybe_unused]] const ExecutionContext& context,
+                                   const miopen::GradientDescent::ProblemDescription& problem) const
+{
+    if(!(problem.GetvarInDesc().GetType() == miopenFloat ||
+         problem.GetvarInDesc().GetType() == miopenHalf ||
+         problem.GetvarInDesc().GetType() == miopenBFloat16))
+        return false;
+    return true;
+}
+
+ConvSolution
+GradientDescent::GetSolution([[maybe_unused]] const ExecutionContext& context,
+                             const miopen::GradientDescent::ProblemDescription& problem) const
+{
+    auto result = ConvSolution{miopenStatusSuccess};
+
+    auto is_contiguous = problem.IsAllContiguous();
+    auto dtype         = problem.GetvarInDesc().GetType();
+    auto d_dtype       = miopen::GetDataType(dtype);
+    auto nelems        = problem.GetvarInDesc().GetElementSize();
+
+    const auto build_params = KernelBuildParameters{
+        {"MIOPEN_USE_FP16", static_cast<int>(dtype == miopenHalf)},
+        {"MIOPEN_USE_FP32", static_cast<int>(dtype == miopenFloat)},
+        {"MIOPEN_USE_FP64", static_cast<int>(dtype == miopenDouble)},
+        {"MIOPEN_USE_BFP16", static_cast<int>(dtype == miopenBFloat16)},
+        {"D_TYPE", d_dtype == "bfloat16" ? "ushort" : d_dtype},
+    };
+
+    size_t xlocalsize = LOCAL_SIZE;
+    size_t xgridsize  = AlignUp(nelems, xlocalsize);
+    size_t ylocalsize = 1;
+    size_t ygridsize  = 1;
+    size_t zlocalsize = 1;
+    size_t zgridsize  = 1;
+
+    auto kernel         = KernelInfo{};
+    kernel.kernel_file  = "MIOpenGradientDescent.cpp";
+    kernel.comp_options = build_params.GenerateFor(kbp::HIP{});
+
+    kernel.l_wk.push_back(xlocalsize);
+    kernel.l_wk.push_back(ylocalsize);
+    kernel.l_wk.push_back(zlocalsize);
+
+    kernel.g_wk.push_back(xgridsize);
+    kernel.g_wk.push_back(ygridsize);
+    kernel.g_wk.push_back(zgridsize);
+
+    if(is_contiguous)
+    {
+        kernel.kernel_name = "ResourceApplyGradientDescentContiguous";
+        result.construction_params.push_back(kernel);
+
+        result.invoker_factory = [nelems](const std::vector<Kernel>& kernels) {
+            return [=](const Handle& handle_, const AnyInvokeParams& raw_params) {
+                decltype(auto) kernel = handle_.Run(kernels.front());
+                decltype(auto) params = raw_params.CastTo<miopen::GradientDescent::InvokeParams>();
+
+                kernel(params.var_in, params.var_out, params.alpha_in, params.delta_in, nelems);
+            };
+        };
+    }
+    else
+    {
+        kernel.kernel_name = "ResourceApplyGradientDescent";
+        result.construction_params.push_back(kernel);
+
+        result.invoker_factory = [nelems](const std::vector<Kernel>& kernels) {
+            return [=](const Handle& handle_, const AnyInvokeParams& raw_params) {
+                decltype(auto) kernel = handle_.Run(kernels.front());
+                decltype(auto) params = raw_params.CastTo<miopen::GradientDescent::InvokeParams>();
+
+                auto var_in_tv   = get_inner_expanded_tv<5>(deref(params.varInDesc));
+                auto var_out_tv  = get_inner_expanded_tv<5>(deref(params.varOutDesc));
+                auto alpha_in_tv = get_inner_expanded_tv<1>(deref(params.alphaInDesc));
+                auto delta_in_tv = get_inner_expanded_tv<5>(deref(params.deltaInDesc));
+
+                kernel(params.var_in,
+                       params.var_out,
+                       params.alpha_in,
+                       params.delta_in,
+                       nelems,
+                       var_in_tv,
+                       var_out_tv,
+                       alpha_in_tv,
+                       delta_in_tv);
+            };
+        };
+    }
+    return result;
+}
+
+} // namespace GradientDescent
+
+} // namespace solver
+
+} // namespace miopen

--- a/src/solver/gradientdescent/gradientdescent.cpp
+++ b/src/solver/gradientdescent/gradientdescent.cpp
@@ -59,10 +59,11 @@ GradientDescent::GetSolution([[maybe_unused]] const ExecutionContext& context,
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
-    auto is_contiguous = problem.IsAllContiguous();
-    auto dtype         = problem.GetvarInDesc().GetType();
-    auto d_dtype       = miopen::GetDataType(dtype);
-    auto nelems        = problem.GetvarInDesc().GetElementSize();
+    auto is_allpacked_samestride = problem.IsAllPackedSameStride();
+
+    auto dtype   = problem.GetvarInDesc().GetType();
+    auto d_dtype = miopen::GetDataType(dtype);
+    auto nelems  = problem.GetvarInDesc().GetElementSize();
 
     const auto build_params = KernelBuildParameters{
         {"MIOPEN_USE_FP16", static_cast<int>(dtype == miopenHalf)},
@@ -91,7 +92,7 @@ GradientDescent::GetSolution([[maybe_unused]] const ExecutionContext& context,
     kernel.g_wk.push_back(ygridsize);
     kernel.g_wk.push_back(zgridsize);
 
-    if(is_contiguous)
+    if(is_allpacked_samestride)
     {
         kernel.kernel_name = "ResourceApplyGradientDescentContiguous";
         result.construction_params.push_back(kernel);
@@ -117,7 +118,6 @@ GradientDescent::GetSolution([[maybe_unused]] const ExecutionContext& context,
 
                 auto var_in_tv   = get_inner_expanded_tv<5>(deref(params.varInDesc));
                 auto var_out_tv  = get_inner_expanded_tv<5>(deref(params.varOutDesc));
-                auto alpha_in_tv = get_inner_expanded_tv<1>(deref(params.alphaInDesc));
                 auto delta_in_tv = get_inner_expanded_tv<5>(deref(params.deltaInDesc));
 
                 kernel(params.var_in,
@@ -127,7 +127,6 @@ GradientDescent::GetSolution([[maybe_unused]] const ExecutionContext& context,
                        nelems,
                        var_in_tv,
                        var_out_tv,
-                       alpha_in_tv,
                        delta_in_tv);
             };
         };

--- a/test/cpu_gradientdescent.hpp
+++ b/test/cpu_gradientdescent.hpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#pragma once
+
+#include "tensor_holder.hpp"
+#include "tensor_view.hpp"
+#include <miopen/tensor_view_utils.hpp>
+
+template <class T>
+void cpu_GradientDescent(const tensor<T>& var_in,
+                         tensor<T>& var_out,
+                         const tensor<T>& alpha_in,
+                         const tensor<T>& delta_in)
+{
+    auto var_in_tv   = miopen::get_inner_expanded_tv<5>(var_in.desc);
+    auto var_out_tv  = miopen::get_inner_expanded_tv<5>(var_out.desc);
+    auto alpha_in_tv = miopen::get_inner_expanded_tv<1>(alpha_in.desc);
+    auto delta_in_tv = miopen::get_inner_expanded_tv<5>(delta_in.desc);
+
+    uint64_t N = var_in.desc.GetElementSize();
+
+    par_ford(N)([&](uint64_t gid) {
+        auto tensor_layout = tensor_layout_t<5>(var_in_tv, gid);
+        double var   = static_cast<double>(var_in[var_in_tv.get_tensor_view_idx(tensor_layout)]);
+        double alpha = static_cast<double>(alpha_in[alpha_in_tv.get_tensor_view_idx({0})]);
+        double delta =
+            static_cast<double>(delta_in[delta_in_tv.get_tensor_view_idx(tensor_layout)]);
+
+        var -= alpha * delta;
+
+        var_out[var_out_tv.get_tensor_view_idx(tensor_layout)] = static_cast<T>(var);
+    });
+}

--- a/test/gtest/gradientdescent.cpp
+++ b/test/gtest/gradientdescent.cpp
@@ -55,12 +55,12 @@ TEST_P(GPU_GradientDescent_BFP16, Test)
     Verify();
 };
 
-INSTANTIATE_TEST_SUITE_P(Full,
+INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_GradientDescent_FP32,
                          testing::ValuesIn(GradientDescentTestConfigs()));
-INSTANTIATE_TEST_SUITE_P(Full,
+INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_GradientDescent_FP16,
                          testing::ValuesIn(GradientDescentTestConfigs()));
-INSTANTIATE_TEST_SUITE_P(Full,
+INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_GradientDescent_BFP16,
                          testing::ValuesIn(GradientDescentTestConfigs()));

--- a/test/gtest/gradientdescent.cpp
+++ b/test/gtest/gradientdescent.cpp
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "gradientdescent.hpp"
+
+struct GPU_GradientDescent_FP32 : GradientDescentTest<float>
+{
+};
+
+struct GPU_GradientDescent_FP16 : GradientDescentTest<half>
+{
+};
+
+struct GPU_GradientDescent_BFP16 : GradientDescentTest<bfloat16>
+{
+};
+
+TEST_P(GPU_GradientDescent_FP32, Test)
+{
+    RunTest();
+    Verify();
+};
+
+TEST_P(GPU_GradientDescent_FP16, Test)
+{
+    RunTest();
+    Verify();
+};
+
+TEST_P(GPU_GradientDescent_BFP16, Test)
+{
+    RunTest();
+    Verify();
+};
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_GradientDescent_FP32,
+                         testing::ValuesIn(GradientDescentTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_GradientDescent_FP16,
+                         testing::ValuesIn(GradientDescentTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_GradientDescent_BFP16,
+                         testing::ValuesIn(GradientDescentTestConfigs()));

--- a/test/gtest/gradientdescent.hpp
+++ b/test/gtest/gradientdescent.hpp
@@ -73,13 +73,13 @@ struct GradientDescentTestCase
 inline std::vector<GradientDescentTestCase> GradientDescentTestConfigs()
 { // n c d h w lr momentum dampening weightDecay nesterov momentumInitialized
     return {
-        // {{50, 10}, true},
+        {{50, 10}, true},
         {{50, 10}, false},
-        // {{50, 10, 20}, true},
+        {{50, 10, 20}, true},
         {{50, 10, 20}, false},
-        // {{50, 10, 20, 30}, true},
+        {{50, 10, 20, 30}, true},
         {{50, 10, 20, 30}, false},
-        // {{50, 10, 20, 30, 4}, true},
+        {{50, 10, 20, 30, 4}, true},
         {{50, 10, 20, 30, 4}, false},
     };
 }

--- a/test/gtest/gradientdescent.hpp
+++ b/test/gtest/gradientdescent.hpp
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "cpu_gradientdescent.hpp"
+#include "get_handle.hpp"
+#include "random.hpp"
+#include "tensor_holder.hpp"
+#include "verify.hpp"
+#include <gtest/gtest.h>
+#include <miopen/gradientdescent.hpp>
+#include <miopen/miopen.h>
+
+template <class T>
+inline std::ostream& operator<<(std::ostream& os, const std::vector<T>& v)
+{
+    os << '{';
+    for(int i = 0; i < v.size(); ++i)
+    {
+        if(i != 0)
+            os << ',';
+        os << v[i];
+    }
+    os << '}';
+    return os;
+}
+
+struct GradientDescentTestCase
+{
+    std::vector<size_t> dims;
+    bool is_contiguous = true;
+
+    friend std::ostream& operator<<(std::ostream& os, const GradientDescentTestCase& tc)
+    {
+        return os << " dims:" << tc.dims << " is_contiguous:" << tc.is_contiguous;
+    }
+
+    std::vector<size_t> ComputeStrides(std::vector<size_t> inputDim) const
+    {
+        if(!is_contiguous)
+            std::swap(inputDim.front(), inputDim.back());
+        std::vector<size_t> strides(inputDim.size());
+        strides.back() = 1;
+        for(int i = inputDim.size() - 2; i >= 0; --i)
+            strides[i] = strides[i + 1] * inputDim[i + 1];
+        if(!is_contiguous)
+            std::swap(strides.front(), strides.back());
+        return strides;
+    }
+};
+
+inline std::vector<GradientDescentTestCase> GradientDescentTestConfigs()
+{ // n c d h w lr momentum dampening weightDecay nesterov momentumInitialized
+    return {
+        // {{50, 10}, true},
+        {{50, 10}, false},
+        // {{50, 10, 20}, true},
+        {{50, 10, 20}, false},
+        // {{50, 10, 20, 30}, true},
+        {{50, 10, 20, 30}, false},
+        // {{50, 10, 20, 30, 4}, true},
+        {{50, 10, 20, 30, 4}, false},
+    };
+}
+
+template <typename T = float>
+struct GradientDescentTest : public ::testing::TestWithParam<GradientDescentTestCase>
+{
+protected:
+    void SetUp() override
+    {
+        auto&& handle          = get_handle();
+        GradientDescent_config = GetParam();
+
+        auto gen_value = [](auto...) { return prng::gen_descreet_uniform_sign<T>(1e-2, 100); };
+
+        auto dims    = GradientDescent_config.dims;
+        auto strides = GradientDescent_config.ComputeStrides(dims);
+
+        var_in   = tensor<T>{dims, strides}.generate(gen_value);
+        var_out  = tensor<T>{dims};
+        alpha_in = tensor<T>{1}.generate(gen_value);
+        delta_in = tensor<T>{dims}.generate(gen_value);
+
+        ref_var_out = tensor<T>(dims);
+
+        var_in_dev   = handle.Write(var_in.data);
+        var_out_dev  = handle.Write(var_out.data);
+        alpha_in_dev = handle.Write(alpha_in.data);
+        delta_in_dev = handle.Write(delta_in.data);
+    }
+
+    void RunTest()
+    {
+        auto&& handle = get_handle();
+        std::fill(var_out.begin(), var_out.end(), 0);
+        std::fill(ref_var_out.begin(), ref_var_out.end(), 0);
+
+        cpu_GradientDescent<T>(var_in, ref_var_out, alpha_in, delta_in);
+        miopenStatus_t status = miopenStatusSuccess;
+
+        status = miopen::GradientDescent::GradientDescent(handle,
+                                                          var_in.desc,
+                                                          var_in_dev.get(),
+                                                          var_out.desc,
+                                                          var_out_dev.get(),
+                                                          alpha_in.desc,
+                                                          alpha_in_dev.get(),
+                                                          delta_in.desc,
+                                                          delta_in_dev.get());
+        ASSERT_EQ(status, miopenStatusSuccess);
+        var_out.data = handle.Read<T>(var_out_dev, var_out.data.size());
+    }
+
+    void Verify()
+    {
+        double threshold = std::numeric_limits<T>::epsilon();
+        auto error       = miopen::rms_range(ref_var_out, var_out);
+
+        ASSERT_EQ(miopen::range_distance(ref_var_out), miopen::range_distance(var_out));
+        EXPECT_LT(error, threshold * 10) << "Error var_out beyond tolerance Error:" << error
+                                         << ",  Thresholdx10: " << threshold * 10;
+    }
+    GradientDescentTestCase GradientDescent_config;
+
+    tensor<T> var_in;
+    tensor<T> var_out;
+    tensor<T> alpha_in;
+    tensor<T> delta_in;
+
+    tensor<T> ref_var_out;
+
+    miopen::Allocator::ManageDataPtr var_in_dev;
+    miopen::Allocator::ManageDataPtr var_out_dev;
+    miopen::Allocator::ManageDataPtr alpha_in_dev;
+    miopen::Allocator::ManageDataPtr delta_in_dev;
+};


### PR DESCRIPTION
* Added ResourceApplyGradientDescent.

* Added driver test and gtest for ResourceApplyGradientDescent.

* New API is guarded by MIOPEN_BETA_API macro.

* Compared to ROCm pytorch: [Link](https://morehio-my.sharepoint.com/:x:/r/personal/kyeonghwan_ryu_moreh_io/_layouts/15/Doc.aspx?sourcedoc=%7B8DFA737D-50B3-4EE2-BC13-75D1A88BD014%7D&file=ResourceApplyGradientDescent.xlsx&action=default&mobile)

* Average over all cases:

* ResourceApplyGradientDescent

|   Type    | Forward |
|----------|----------|
| float16   |   2.08    | 
| float32   |   1.92    | 
| bfloat16 |   2.10    |