### PR TITLE
[MV-1477] Implement CosineSimilarity

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -39,3 +39,4 @@ The MIOpen API library is structured as follows:
   * :doc:`ReLU <../doxygen/html/group___re_l_u>` (experimental)
   * :doc:`Kthvalue <../doxygen/html/group__kthvalue>` (experimental)
   * :doc:`GLU <../doxygen/html/group__glu>` (experimental)
+  * :doc:`CosineSimilarity <../doxygen/html/group__CosineSimilarity>` (experimental)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(MIOpenDriver
     dm_convfp16.cpp
     dm_convfp8.cpp
     dm_convint8.cpp
+    dm_cosinesimilarity.cpp
     dm_dropout.cpp
     dm_fusion.cpp
     dm_gemm.cpp

--- a/driver/cosinesimilarity_driver.hpp
+++ b/driver/cosinesimilarity_driver.hpp
@@ -297,16 +297,15 @@ int CosineSimilarityDriver<Tgpu, Tref>::GetandSetData()
             out_len.push_back(max(in1_len[i], in2_len[i]));
         }
     }
-    auto out_stride = ComputeStrides(out_len);
 
     if(forw == 0 || forw == 1)
     {
-        SetTensorNd(outputTensor, out_len, out_stride, data_type);
+        SetTensorNd(outputTensor, out_len, data_type);
     }
 
     if(forw == 0 || forw == 2)
     {
-        SetTensorNd(outputGradTensor, out_len, out_stride, data_type);
+        SetTensorNd(outputGradTensor, out_len, data_type);
         SetTensorNd(input1GradTensor, in1_len, in1_stride, data_type);
         SetTensorNd(input2GradTensor, in2_len, in2_stride, data_type);
     }

--- a/driver/cosinesimilarity_driver.hpp
+++ b/driver/cosinesimilarity_driver.hpp
@@ -139,12 +139,12 @@ int mloCosineSimilarityBackward(const miopenTensorDescriptor_t input1Desc,
         xn = xn > eps ? sqrt(xn) : sqrt(eps);
         yn = yn > eps ? sqrt(yn) : sqrt(eps);
 
-        Tgpu output         = outputGrad[output_grad_tv.get_tensor_view_idx(out_layout)];
-        double scale        = output / (xn * yn);
-        double axpy_scale_x = -scale * xy / (xn * xn);
-        double axpy_scale_y = -scale * xy / (yn * yn);
-
         out_layout.layout[dim] = 0;
+        Tgpu output            = outputGrad[output_grad_tv.get_tensor_view_idx(out_layout)];
+        double scale           = output / (xn * yn);
+        double axpy_scale_x    = -scale * xy / (xn * xn);
+        double axpy_scale_y    = -scale * xy / (yn * yn);
+
         for(size_t k = 0; k < input1_tv.size[dim]; ++k)
         {
             Tgpu x = input1[input1_tv.get_tensor_view_idx(out_layout)];

--- a/driver/cosinesimilarity_driver.hpp
+++ b/driver/cosinesimilarity_driver.hpp
@@ -1,0 +1,454 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include "InputFlags.hpp"
+#include "driver.hpp"
+#include "tensor_driver.hpp"
+#include "tensor_view.hpp"
+#include "timer.hpp"
+#include "random.hpp"
+
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include <../test/verify.hpp>
+
+#include <miopen/errors.hpp>
+#include <miopen/miopen.h>
+#include <miopen/tensor_view_utils.hpp>
+
+template <typename Tgpu, typename Tcheck>
+int mloCosineSimilarityForward(const miopenTensorDescriptor_t input1Desc,
+                               const Tgpu* input1,
+                               const miopenTensorDescriptor_t input2Desc,
+                               const Tgpu* input2,
+                               const miopenTensorDescriptor_t outputDesc,
+                               Tcheck* output,
+                               uint32_t dim,
+                               float eps)
+{
+    auto out_sz                   = miopen::deref(outputDesc).GetElementSize();
+    tensor_view_t<5> input1_tv    = miopen::get_inner_expanded_tv<5>(miopen::deref(input1Desc));
+    tensor_view_t<5> input2_tv    = miopen::get_inner_expanded_tv<5>(miopen::deref(input2Desc));
+    tensor_view_t<4> output_tv_4d = miopen::get_inner_expanded_tv<4>(miopen::deref(outputDesc));
+    tensor_view_t<5> output_tv;
+
+    uint64_t[4] out_size = output_tv_4d.size;
+    std::vector<uint64_t> out_strides;
+
+    for(auto o = 0; o < out_sz; o++)
+    {
+        Tgpu xy = 0;
+        Tgpu xn = 0;
+        Tgpu yn = 0;
+
+        tensor_layout_t<5> out_layout(output_tv, o);
+
+        // TODO: tensor view for dim into out_tv
+        for(size_t k = 0; k < input1_tv.size[dim]; ++k)
+        {
+            Tgpu x = input1[input1_tv.get_tensor_view_idx(out_layout)];
+            Tgpu y = input2[input2_tv.get_tensor_view_idx(out_layout)];
+
+            xy += x * y;
+            xn += x * x;
+            yn += y * y;
+
+            out_layout.layout[dim]++;
+        }
+
+        xn = xn > eps ? xn : eps;
+        yn = yn > eps ? yn : eps;
+
+        output[output_tv.get_tensor_view_idx(out_layout)] = xy / sqrt(xn * yn);
+    }
+}
+
+template <typename Tgpu, typename Tcheck>
+int mloEmbeddingBackward(const miopenTensorDescriptor_t inputDesc,
+                         const int64_t* input,
+                         const miopenTensorDescriptor_t outputGradDesc,
+                         const Tgpu* outputGrad,
+                         const miopenTensorDescriptor_t weightGradDesc,
+                         Tcheck* weightGradHost,
+                         const int32_t* indices_freq,
+                         int64_t padding_idx)
+{
+    auto input_tv       = miopen::get_inner_expanded_tv<4>(miopen::deref(inputDesc));
+    auto outGrad_tv     = miopen::get_inner_expanded_tv<5>(miopen::deref(outputGradDesc));
+    auto weightGrad_tv  = miopen::get_inner_expanded_tv<2>(miopen::deref(weightGradDesc));
+    auto weightGrad_len = miopen::deref(weightGradDesc).GetLengths();
+    auto embedding_dim  = weightGrad_len[1];
+    auto num_embeddings = weightGrad_len[0];
+    auto outGrad_numel  = miopen::deref(outputGradDesc).GetElementSize();
+    for(size_t o = 0; o < outGrad_numel; o++)
+    {
+        size_t i = o / embedding_dim, j = o % embedding_dim;
+
+        tensor_layout_t<4> input_layout(input_tv, i);
+        size_t input_idx      = input_tv.get_tensor_view_idx(input_layout);
+        int64_t embedding_idx = input[input_idx];
+
+        if(embedding_idx == padding_idx)
+            continue;
+
+        if(embedding_idx >= 0 && embedding_idx < num_embeddings)
+        {
+            Tcheck scale =
+                indices_freq
+                    ? (static_cast<Tcheck>(1.0f) / static_cast<Tcheck>(indices_freq[input_idx]))
+                    : static_cast<Tcheck>(1.0f);
+            size_t weight_grad_idx = weightGrad_tv.get_tensor_view_idx({embedding_idx, j});
+            tensor_layout_t<5> outGrad_layout(outGrad_tv, o);
+            weightGradHost[weight_grad_idx] +=
+                outputGrad[outGrad_tv.get_tensor_view_idx(outGrad_layout)] * scale;
+        }
+    }
+
+    return 0;
+}
+
+template <typename Tgpu, typename Tref>
+class CosineSimilarityDriver : public Driver
+{
+public:
+    CosineSimilarityDriver() : Driver()
+    {
+        miopenCreateTensorDescriptor(&input1Tensor);
+        miopenCreateTensorDescriptor(&input2Tensor);
+        miopenCreateTensorDescriptor(&outputTensor);
+
+        data_type = miopen_type<Tgpu>{};
+    }
+
+    std::vector<int> ComputeStrides(std::vector<int> input);
+    int AddCmdLineArgs() override;
+    int ParseCmdLineArgs(int argc, char* argv[]) override;
+    InputFlags& GetInputFlags() override { return inflags; }
+
+    int GetandSetData() override;
+    int AllocateBuffersAndCopy() override;
+
+    int RunForwardGPU() override;
+    int RunForwardCPU();
+
+    int RunBackwardGPU() override;
+    int RunBackwardCPU();
+
+    Tref GetTolerance();
+
+    int VerifyBackward() override;
+    int VerifyForward() override;
+    ~CosineSimilarityDriver() override
+    {
+        miopenDestroyTensorDescriptor(input1Tensor);
+        miopenDestroyTensorDescriptor(input2Tensor);
+        miopenDestroyTensorDescriptor(outputTensor);
+    }
+
+private:
+    InputFlags inflags;
+
+    int forw;
+    bool isContiguous;
+
+    // Forwards
+    miopenTensorDescriptor_t input1Tensor;
+    miopenTensorDescriptor_t input2Tensor;
+    miopenTensorDescriptor_t outputTensor;
+
+    std::unique_ptr<GPUMem> in1_dev;
+    std::unique_ptr<GPUMem> in2_dev;
+    std::unique_ptr<GPUMem> out_dev;
+
+    std::vector<Tgpu> in1;
+    std::vector<Tgpu> in2;
+    std::vector<Tref> out;
+
+    uint32_t dim;
+    float eps;
+};
+
+template <typename Tgpu, typename Tref>
+int CosineSimilarityDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
+{
+    inflags.Parse(argc, argv);
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        miopenEnableProfiling(GetHandle(), true);
+    }
+
+    forw = inflags.GetValueInt("forw");
+
+    if(forw != 1)
+    {
+        MIOPEN_THROW("Invalid Forward|Backward Mode");
+    }
+
+    isContiguous = inflags.GetValueInt("is_contiguous") == 0 ? false : true;
+    dim          = inflags.GetValueInt("dim");
+    eps          = inflags.GetValueDouble("eps");
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int CosineSimilarityDriver<Tgpu, Tref>::GetandSetData()
+{
+    std::vector<int> in1_len = inflags.GetValueTensor("input1_dims").lengths;
+    auto in1_stride          = ComputeStrides(in1_len);
+    SetTensorNd(input1Tensor, in1_len, in1_stride, data_type);
+
+    std::vector<int> in2_len = inflags.GetValueTensor("input2_dims").lengths;
+    auto in2_stride          = ComputeStrides(in2_len);
+    SetTensorNd(input2Tensor, in2_len, in2_stride, data_type);
+
+    std::vector<int> out_len;
+
+    for(int i = 0; i < in1_len.size(); i++)
+    {
+        if(i != dim)
+        {
+            out_len.push_back(max(in1_len[i], in2_len[i]));
+        }
+    }
+    auto out_stride = ComputeStrides(out_len);
+    SetTensorNd(outputTensor, out_len, out_stride, data_type);
+
+    return miopenStatusSuccess;
+}
+
+// Equivalent to: tensor.tranpose(0, -1).contiguous().tranpose(0, -1) incase contiguous = False
+template <typename Tgpu, typename Tref>
+std::vector<int> CosineSimilarityDriver<Tgpu, Tref>::ComputeStrides(std::vector<int> inputDim)
+{
+    if(!isContiguous)
+        std::swap(inputDim.front(), inputDim.back());
+    std::vector<int> strides(inputDim.size());
+    strides.back() = 1;
+    for(int i = inputDim.size() - 2; i >= 0; --i)
+        strides[i] = strides[i + 1] * inputDim[i + 1];
+    if(!isContiguous)
+        std::swap(strides.front(), strides.back());
+    return strides;
+}
+
+template <typename Tgpu, typename Tref>
+int CosineSimilarityDriver<Tgpu, Tref>::AddCmdLineArgs()
+{
+    inflags.AddInputFlag("forw", 'F', "1", "Run only Forward (1) (Default=1)", "int");
+    inflags.AddTensorFlag(
+        "input1_dims", 'I', "40x40", "The dimensional lengths of the input tensor (Default=40x40)");
+    inflags.AddTensorFlag("input2_dims",
+                          'J',
+                          "40x40",
+                          "The dimensional lengths of the input2 tensor (Default=40x40)");
+    inflags.AddInputFlag(
+        "dim", 'D', "1", "Dimension where cosine similarity is computed (Default=1)");
+    inflags.AddInputFlag(
+        "eps", 'E', "1e-8", "Small value to avoid division by zero (Default=1e-8)");
+    inflags.AddInputFlag("iter", 'i', "10", "Number of Iterations (Default=10)", "int");
+    inflags.AddInputFlag(
+        "is_contiguous", 'C', "1", "Is Tensor Contiguous (1) or not (0) (Default=1)", "int");
+    inflags.AddInputFlag("verify", 'V', "1", "Verify Each Layer (Default=1)", "int");
+    inflags.AddInputFlag("time", 't', "0", "Time Each Layer (Default=0)", "int");
+    inflags.AddInputFlag(
+        "wall", 'w', "0", "Wall-clock Time Each Layer, Requires time == 1 (Default=0)", "int");
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int CosineSimilarityDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
+{
+    uint32_t ctx = 0;
+
+    size_t in1_sz = GetTensorSpace(input1Tensor);
+    size_t in2_sz = GetTensorSpace(input2Tensor);
+    size_t out_sz = GetTensorSpace(outputTensor);
+
+    if(forw == 1)
+    {
+        // GPU allocation
+        in1_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, in1_sz, sizeof(Tgpu)));
+        in2_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, in2_sz, sizeof(Tgpu)));
+        out_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, out_sz, sizeof(Tgpu)));
+
+        // GPU host allocation
+        in1 = std::vector<Tgpu>(in1_sz, static_cast<Tgpu>(0));
+        in2 = std::vector<Tgpu>(in2_sz, static_cast<Tgpu>(0));
+
+        // CPU allocation
+        out = std::vector<Tgpu>(out_sz, static_cast<Tref>(0));
+
+        for(int i = 0; i < in1_sz; i++)
+        {
+            in1[i] = prng::gen_A_to_B(static_cast<Tgpu>(0.0), static_cast<Tgpu>(1.0));
+        }
+
+        for(int i = 0; i < in2_sz; i++)
+        {
+            in2[i] = prng::gen_A_to_B(static_cast<Tgpu>(0.0), static_cast<Tgpu>(1.0));
+        }
+
+        if(in1_dev->ToGPU(GetStream(), in1.data()) != 0)
+        {
+            std::cerr << "Error copying (input1) to GPU, size: " << in1_dev->GetSize() << std::endl;
+            return miopenStatusInternalError;
+        }
+        if(in2_dev->ToGPU(GetStream(), in2.data()) != 0)
+        {
+            std::cerr << "Error copying (input2) to GPU, size: " << in2_dev->GetSize() << std::endl;
+            return miopenStatusInternalError;
+        }
+        if(out_dev->ToGPU(GetStream(), out.data()) != 0)
+        {
+            std::cerr << "Error copying (output) to GPU, size: " << out_dev->GetSize() << std::endl;
+            return miopenStatusInternalError;
+        }
+    }
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int CosineSimilarityDriver<Tgpu, Tref>::RunForwardGPU()
+{
+    return miopenStatusNotImplemented;
+}
+
+template <typename Tgpu, typename Tref>
+int CosineSimilarityDriver<Tgpu, Tref>::RunForwardCPU()
+{
+    return miopenStatusNotImplemented;
+}
+
+template <typename Tgpu, typename Tref>
+int CosineSimilarityDriver<Tgpu, Tref>::RunBackwardGPU()
+{
+    // float kernel_total_time = 0;
+    // float kernel_first_time = 0;
+    // Timer t;
+    // START_TIME;
+    // for(int i = 0; i < inflags.GetValueInt("iter"); i++)
+    //{
+    //    miopenStatus_t status = miopenEmbeddingBackward(GetHandle(),
+    //                                                    inputTensor,
+    //                                                    in_dev->GetMem(),
+    //                                                    outputTensorGrad,
+    //                                                    outGrad_dev->GetMem(),
+    //                                                    weightTensorGrad,
+    //                                                    weightGrad_dev->GetMem(),
+    //                                                    indices_freq.data(),
+    //                                                    padding_idx);
+    //
+    //    MIOPEN_THROW_IF(status != miopenStatusSuccess, "Error in miopenEmbeddingBackward");
+    //
+    //    float time = 0.0;
+    //    miopenGetKernelTime(GetHandle(), &time);
+    //    kernel_total_time += time;
+    //    if(i == 0)
+    //        kernel_first_time = time;
+    //}
+    //
+    // if(inflags.GetValueInt("time") == 1)
+    //{
+    //    STOP_TIME
+    //    int iter = inflags.GetValueInt("iter");
+    //    if(WALL_CLOCK)
+    //        std::cout << "Wall-clock Time Backward Embedding Elapsed: " << t.gettime_ms() / iter
+    //                  << " ms\n";
+    //    float kernel_average_time =
+    //        iter > 1 ? (kernel_total_time - kernel_first_time) / (iter - 1) : kernel_first_time;
+    //    std::cout << "GPU Kernel Time Backward Embedding Elapsed: " << kernel_average_time
+    //              << " ms\n";
+    //}
+    //
+    // if(weightGrad_dev->FromGPU(GetStream(), weightGrad.data()) != 0)
+    //{
+    //    std::cerr << "Error copying (weightGrad_dev) from GPU, size: " <<
+    //    weightGrad_dev->GetSize()
+    //              << std::endl;
+    //    return miopenStatusInternalError;
+    //}
+
+    return miopenStatusNotImplemented;
+}
+
+template <typename Tgpu, typename Tref>
+Tref CosineSimilarityDriver<Tgpu, Tref>::GetTolerance()
+{
+    Tref tolerance = std::numeric_limits<Tgpu>::epsilon() * 10;
+    return tolerance;
+}
+
+template <typename Tgpu, typename Tref>
+int CosineSimilarityDriver<Tgpu, Tref>::VerifyForward()
+{
+    return miopenStatusNotImplemented;
+}
+
+template <typename Tgpu, typename Tref>
+int CosineSimilarityDriver<Tgpu, Tref>::RunBackwardCPU()
+{
+    // mloEmbeddingBackward(inputTensor,
+    //                     in.data(),
+    //                     outputTensorGrad,
+    //                     outGrad.data(),
+    //                     weightTensorGrad,
+    //                     weightGradHost.data(),
+    //                     indices_freq.data(),
+    //                     padding_idx);
+
+    return miopenStatusNotImplemented;
+}
+
+template <typename Tgpu, typename Tref>
+int CosineSimilarityDriver<Tgpu, Tref>::VerifyBackward()
+{
+    // RunBackwardCPU();
+    // const Tref tolerance = GetTolerance();
+    // auto error           = miopen::rms_range(weightGradHost, weightGrad);
+    //
+    // if(!std::isfinite(error) || error > tolerance)
+    //{
+    //    std::cout << "Backward Embedding FAILED: " << error << " > " << tolerance << std::endl;
+    //    return EC_VerifyBwd;
+    //}
+    // else
+    //{
+    //    std::cout << "Backward Embedding OK on CPU reference (" << error << " < " << tolerance
+    //              << ')' << std::endl;
+    //}
+
+    return miopenStatusNotImplemented;
+}

--- a/driver/dm_cosinesimilarity.cpp
+++ b/driver/dm_cosinesimilarity.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "cosinesimilarity_driver.hpp"
+#include "registry_driver_maker.hpp"
+
+static Driver* makeDriver(const std::string& base_arg)
+{
+    if(base_arg == "cosinesimilarity")
+        return new CosineSimilarityDriver<float, float>();
+    if(base_arg == "cosinesimilarityfp16")
+        return new CosineSimilarityDriver<float16, float>();
+    if(base_arg == "cosinesimilaritybfp16")
+        return new CosineSimilarityDriver<bfloat16, float>();
+    return nullptr;
+}
+
+REGISTER_DRIVER_MAKER(makeDriver);

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -314,7 +314,7 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
            "adamw[fp16], ampadamw, transformersadamw[fp16], transformersampadamw, "
            "getitem[bfp16|fp16], reducecalculation[bfp16|fp16], rope[bfp16|fp16], "
            "prelu[bfp16|fp16], kthvalue[bfp16|fp16], glu[bfp16|fp16], softmarginloss[bfp16|fp16], "
-           "multimarginloss[bfp16|fp16]\n");
+           "multimarginloss[bfp16|fp16], cosinesimilarity[bfp16|fp16]\n");
     exit(0); // NOLINT (concurrency-mt-unsafe)
 }
 
@@ -352,7 +352,8 @@ inline std::string ParseBaseArg(int argc, char* argv[])
        arg != "kthvaluebfp16" && arg != "glu" && arg != "glufp16" && arg != "glubfp16" &&
        arg != "softmarginloss" && arg != "softmarginlossfp16" && arg != "softmarginlossbfp16" &&
        arg != "multimarginloss" && arg != "multimarginlossfp16" && arg != "multimarginlossbfp16" &&
-       arg != "--version")
+       arg != "cosinesimilarity" && arg != "cosinesimilarityfp16" &&
+       arg != "cosinesimilaritybfp16" && arg != "--version")
     {
         printf("FAILED: Invalid Base Input Argument\n");
         Usage();

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -72,6 +72,7 @@
  * @defgroup ReduceCalculation
  * @defgroup RotaryPositionalEmbeddings
  * @defgroup ReLU
+ * @defgroup CosineSimilarity
  *
  */
 
@@ -8174,6 +8175,40 @@ MIOPEN_EXPORT miopenStatus_t miopenMultiMarginLossForward(miopenHandle_t handle,
 
 /** @} */
 // CLOSEOUT LossFunction DOXYGEN GROUP
+#endif // MIOPEN_BETA_API
+
+#ifdef MIOPEN_BETA_API
+/** @addtogroup CosineSimilarity
+ *
+ *  @{
+ */
+
+/*! @brief Execute CosineSimilarity forward layer
+ *
+ * @param handle                   MIOpen handle (input)
+ * @param input1Desc               Tensor descriptor for first input tensor (input)
+ * @param input1                   First input tensor (input)
+ * @param input2Desc               Tensor descriptor for second input tensor (input)
+ * @param input2                   Second input tensor (input)
+ * @param outputDesc               Tensor descriptor for output tensor (input)
+ * @param output                   Output tensor (output)
+ * @param dim                      Dimension where cosine similarity is computed (input)
+ * @param eps                      Small value to avoid division by zero (input)
+ * @return                         miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenCosineSimilarityForward(miopenHandle_t handle,
+                              const miopenTensorDescriptor_t input1Desc,
+                              const void* input1,
+                              const miopenTensorDescriptor_t input2Desc,
+                              const void* input2,
+                              const miopenTensorDescriptor_t outputDesc,
+                              void* output,
+                              uint32_t dim,
+                              float eps);
+
+/** @} */
+// CLOSEOUT CosineSimilarity DOXYGEN GROUP
 #endif // MIOPEN_BETA_API
 
 #ifdef __cplusplus

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -8207,6 +8207,38 @@ miopenCosineSimilarityForward(miopenHandle_t handle,
                               uint32_t dim,
                               float eps);
 
+/*! @brief Execute CosineSimilarity backward layer
+ *
+ * @param handle                   MIOpen handle (input)
+ * @param input1Desc               Tensor descriptor for first input tensor (input)
+ * @param input1                   First input tensor (input)
+ * @param input2Desc               Tensor descriptor for second input tensor (input)
+ * @param input2                   Second input tensor (input)
+ * @param outputGradDesc           Tensor descriptor for output gradient tensor (input)
+ * @param outputGrad               Output gradient tensor (input)
+ * @param input1GradDesc           Tensor descriptor for first input gradient tensor (input)
+ * @param input1Grad               First input gradient tensor (output)
+ * @param input2GradDesc           Tensor descriptor for second input gradient tensor (input)
+ * @param input2Grad               Second input gradient tensor (output)
+ * @param dim                      Dimension where cosine similarity is computed (input)
+ * @param eps                      Small value to avoid division by zero (input)
+ * @return                         miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenCosineSimilarityBackward(miopenHandle_t handle,
+                               const miopenTensorDescriptor_t input1Desc,
+                               const void* input1,
+                               const miopenTensorDescriptor_t input2Desc,
+                               const void* input2,
+                               const miopenTensorDescriptor_t outputGradDesc,
+                               const void* outputGrad,
+                               const miopenTensorDescriptor_t input1GradDesc,
+                               void* input1Grad,
+                               const miopenTensorDescriptor_t input2GradDesc,
+                               void* input2Grad,
+                               uint32_t dim,
+                               float eps);
+
 /** @} */
 // CLOSEOUT CosineSimilarity DOXYGEN GROUP
 #endif // MIOPEN_BETA_API

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -302,6 +302,7 @@ set( MIOpen_Source
     solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
     solver/conv_ocl_dir2Dfwd_fused.cpp
     solver/conv_winoRxS_fused.cpp
+    solver/cosinesimilarity/backward_cosinesimilarity.cpp
     solver/cosinesimilarity/forward_cosinesimilarity.cpp
     solver/glu/backward_glu.cpp
     solver/glu/forward_glu.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,8 @@ set( MIOpen_Source
     conv_algo_name.cpp
     convolution.cpp
     convolution_api.cpp
+    cosinesimilarity/problem_description.cpp
+    cosinesimilarity_api.cpp
     ctc.cpp
     ctc_api.cpp
     db.cpp
@@ -300,6 +302,7 @@ set( MIOpen_Source
     solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
     solver/conv_ocl_dir2Dfwd_fused.cpp
     solver/conv_winoRxS_fused.cpp
+    solver/cosinesimilarity/forward_cosinesimilarity.cpp
     solver/glu/backward_glu.cpp
     solver/glu/forward_glu.cpp
     solver/groupnorm/forward_groupnorm.cpp
@@ -529,6 +532,7 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         kernels/MIOpenConvDirUni.cl
         kernels/MIOpenConvDirBatchNormActiv.cl
         kernels/MIOpenConvDirGenFwd.cl
+        kernels/MIOpenCosineSimilarity.cpp
         kernels/MIOpenGLU.cpp
         kernels/MIOpenGroupNorm.cpp
         kernels/MIOpenGetitem.cpp
@@ -667,6 +671,7 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         adam.cpp
         addlayernorm.cpp
         cat.cpp
+        cosinesimilarity.cpp
         exec_utils.cpp
         groupnorm.cpp
         getitem.cpp

--- a/src/cosinesimilarity.cpp
+++ b/src/cosinesimilarity.cpp
@@ -86,7 +86,34 @@ miopenStatus_t CosineSimilarityBackward(Handle& handle,
                                         uint32_t dim,
                                         float eps)
 {
-    const auto problem = miopen::cosinesimilarity::BwdProblemDescription {}
+    const auto problem = miopen::cosinesimilarity::BwdProblemDescription{
+        input1Desc, input2Desc, outputGradDesc, input1GradDesc, input2GradDesc, dim, eps};
+
+    const auto invoke_params = [&]() {
+        auto tmp           = cosinesimilarity::BwdInvokeParams{};
+        tmp.type           = InvokeType::Run;
+        tmp.input1Desc     = &input1Desc;
+        tmp.input2Desc     = &input2Desc;
+        tmp.outputGradDesc = &outputGradDesc;
+        tmp.input1GradDesc = &input1GradDesc;
+        tmp.input2GradDesc = &input2GradDesc;
+        tmp.input1         = input1;
+        tmp.input2         = input2;
+        tmp.outputGrad     = outputGrad;
+        tmp.input1Grad     = input1Grad;
+        tmp.input2Grad     = input2Grad;
+        tmp.dim            = dim;
+        tmp.eps            = eps;
+        return tmp;
+    }();
+
+    const auto algo = AlgorithmName{"CosineSimilarityBackward"};
+    const auto solvers =
+        solver::SolverContainer<solver::cosinesimilarity::CosineSimilarityBackward>{};
+
+    solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
+
+    return miopenStatusSuccess;
 }
 
 } // namespace cosinesimilarity

--- a/src/cosinesimilarity.cpp
+++ b/src/cosinesimilarity.cpp
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/common.hpp>
+#include <miopen/cosinesimilarity.hpp>
+#include <miopen/cosinesimilarity/invoke_params.hpp>
+#include <miopen/cosinesimilarity/problem_description.hpp>
+#include <miopen/cosinesimilarity/solvers.hpp>
+#include <miopen/find_solution.hpp>
+#include <miopen/tensor.hpp>
+
+namespace miopen {
+
+namespace cosinesimilarity {
+
+miopenStatus_t CosineSimilarityForward(Handle& handle,
+                                       const TensorDescriptor& input1Desc,
+                                       ConstData_t input1,
+                                       const TensorDescriptor& input2Desc,
+                                       ConstData_t input2,
+                                       const TensorDescriptor& outputDesc,
+                                       Data_t output,
+                                       uint32_t dim,
+                                       float eps)
+{
+    const auto problem = miopen::cosinesimilarity::FwdProblemDescription{
+        input1Desc, input2Desc, outputDesc, dim, eps};
+
+    const auto invoke_params = [&]() {
+        auto tmp       = cosinesimilarity::FwdInvokeParams{};
+        tmp.type       = InvokeType::Run;
+        tmp.input1Desc = &input1Desc;
+        tmp.input2Desc = &input2Desc;
+        tmp.outputDesc = &outputDesc;
+        tmp.input1     = input1;
+        tmp.input2     = input2;
+        tmp.output     = output;
+        tmp.dim        = dim;
+        tmp.eps        = eps;
+        return tmp;
+    }();
+
+    const auto algo = AlgorithmName{"CosineSimilarityForward"};
+    const auto solvers =
+        solver::SolverContainer<solver::cosinesimilarity::CosineSimilarityForward>{};
+
+    solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
+
+    return miopenStatusSuccess;
+}
+
+miopenStatus_t CosineSimilarityBackward(Handle& handle,
+                                        const TensorDescriptor& input1Desc,
+                                        ConstData_t input1,
+                                        const TensorDescriptor& input2Desc,
+                                        ConstData_t input2,
+                                        const TensorDescriptor& outputGradDesc,
+                                        ConstData_t outputGrad,
+                                        const TensorDescriptor& input1GradDesc,
+                                        Data_t input1Grad,
+                                        const TensorDescriptor& input2GradDesc,
+                                        Data_t input2Grad,
+                                        uint32_t dim,
+                                        float eps)
+{
+    const auto problem = miopen::cosinesimilarity::BwdProblemDescription {}
+}
+
+} // namespace cosinesimilarity
+
+} // namespace miopen

--- a/src/cosinesimilarity/problem_description.cpp
+++ b/src/cosinesimilarity/problem_description.cpp
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/cosinesimilarity/problem_description.hpp>
+#include <miopen/names.hpp>
+
+#include <sstream>
+
+namespace miopen {
+
+namespace cosinesimilarity {
+
+NetworkConfig FwdProblemDescription::MakeNetworkConfig() const
+{
+    auto dtype        = input1Desc.GetType();
+    auto output_numel = outputDesc.GetElementSize();
+
+    std::ostringstream ss;
+
+    ss << "cosinesimilarity_fwd";
+    ss << "dtype" << dtype;
+    ss << "output_size" << output_numel;
+
+    return NetworkConfig{ss.str()};
+}
+
+NetworkConfig BwdProblemDescription::MakeNetworkConfig() const
+{
+    auto dtype        = input1Desc.GetType();
+    auto output_numel = outputGradDesc.GetElementSize();
+
+    std::ostringstream ss;
+
+    ss << "cosinesimilarity_bwd";
+    ss << "dtype" << dtype;
+    ss << "output_size" << output_numel;
+
+    return NetworkConfig{ss.str()};
+}
+
+} // namespace cosinesimilarity
+
+} // namespace miopen

--- a/src/cosinesimilarity_api.cpp
+++ b/src/cosinesimilarity_api.cpp
@@ -24,13 +24,13 @@
  *
  *******************************************************************************/
 
-#include "miopen/miopen.h"
 #include <cstdint>
 #include <miopen/common.hpp>
 #include <miopen/cosinesimilarity.hpp>
 #include <miopen/errors.hpp>
 #include <miopen/handle.hpp>
 #include <miopen/logger.hpp>
+#include <miopen/miopen.h>
 #include <miopen/tensor_ops.hpp>
 
 extern "C" miopenStatus_t miopenCosineSimilarityForward(miopenHandle_t handle,
@@ -55,5 +55,50 @@ extern "C" miopenStatus_t miopenCosineSimilarityForward(miopenHandle_t handle,
                                                           DataCast(output),
                                                           dim,
                                                           eps);
+    });
+}
+
+extern "C" miopenStatus_t
+miopenCosineSimilarityBackward(miopenHandle_t handle,
+                               const miopenTensorDescriptor_t input1Desc,
+                               const void* input1,
+                               const miopenTensorDescriptor_t input2Desc,
+                               const void* input2,
+                               const miopenTensorDescriptor_t outputGradDesc,
+                               const void* outputGrad,
+                               const miopenTensorDescriptor_t input1GradDesc,
+                               void* input1Grad,
+                               const miopenTensorDescriptor_t input2GradDesc,
+                               void* input2Grad,
+                               uint32_t dim,
+                               float eps)
+{
+    MIOPEN_LOG_FUNCTION(handle,
+                        input1Desc,
+                        input1,
+                        input2Desc,
+                        input2,
+                        outputGradDesc,
+                        outputGrad,
+                        input1GradDesc,
+                        input1Grad,
+                        input2GradDesc,
+                        input2Grad,
+                        dim,
+                        eps);
+    return miopen::try_([&] {
+        miopen::cosinesimilarity::CosineSimilarityBackward(miopen::deref(handle),
+                                                           miopen::deref(input1Desc),
+                                                           DataCast(input1),
+                                                           miopen::deref(input2Desc),
+                                                           DataCast(input2),
+                                                           miopen::deref(outputGradDesc),
+                                                           DataCast(outputGrad),
+                                                           miopen::deref(input1GradDesc),
+                                                           DataCast(input1Grad),
+                                                           miopen::deref(input2GradDesc),
+                                                           DataCast(input2Grad),
+                                                           dim,
+                                                           eps);
     });
 }

--- a/src/cosinesimilarity_api.cpp
+++ b/src/cosinesimilarity_api.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "miopen/miopen.h"
+#include <cstdint>
+#include <miopen/common.hpp>
+#include <miopen/cosinesimilarity.hpp>
+#include <miopen/errors.hpp>
+#include <miopen/handle.hpp>
+#include <miopen/logger.hpp>
+#include <miopen/tensor_ops.hpp>
+
+extern "C" miopenStatus_t miopenCosineSimilarityForward(miopenHandle_t handle,
+                                                        const miopenTensorDescriptor_t input1Desc,
+                                                        const void* input1,
+                                                        const miopenTensorDescriptor_t input2Desc,
+                                                        const void* input2,
+                                                        const miopenTensorDescriptor_t outputDesc,
+                                                        void* output,
+                                                        uint32_t dim,
+                                                        float eps)
+{
+    MIOPEN_LOG_FUNCTION(
+        handle, input1Desc, input1, input2Desc, input2, outputDesc, output, dim, eps);
+    return miopen::try_([&] {
+        miopen::cosinesimilarity::CosineSimilarityForward(miopen::deref(handle),
+                                                          miopen::deref(input1Desc),
+                                                          DataCast(input1),
+                                                          miopen::deref(input2Desc),
+                                                          DataCast(input2),
+                                                          miopen::deref(outputDesc),
+                                                          DataCast(output),
+                                                          dim,
+                                                          eps);
+    });
+}

--- a/src/include/miopen/cosinesimilarity.hpp
+++ b/src/include/miopen/cosinesimilarity.hpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 #pragma once
 
+#include "miopen/export_internals.h"
 #include <miopen/common.hpp>
 
 namespace miopen {
@@ -43,6 +44,21 @@ MIOPEN_INTERNALS_EXPORT miopenStatus_t CosineSimilarityForward(Handle& handle,
                                                                Data_t output,
                                                                uint32_t dim,
                                                                float eps);
+
+MIOPEN_INTERNALS_EXPORT miopenStatus_t
+CosineSimilarityBackward(Handle& handle,
+                         const TensorDescriptor& input1Desc,
+                         ConstData_t input1,
+                         const TensorDescriptor& input2Desc,
+                         ConstData_t input2,
+                         const TensorDescriptor& outputGradDesc,
+                         ConstData_t outputGrad,
+                         const TensorDescriptor& input1GradDesc,
+                         Data_t input1Grad,
+                         const TensorDescriptor& input2GradDesc,
+                         Data_t input2Grad,
+                         uint32_t dim,
+                         float eps);
 
 } // namespace cosinesimilarity
 

--- a/src/include/miopen/cosinesimilarity.hpp
+++ b/src/include/miopen/cosinesimilarity.hpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#pragma once
+
+#include <miopen/common.hpp>
+
+namespace miopen {
+
+struct Handle;
+struct TensorDescriptor;
+
+namespace cosinesimilarity {
+
+MIOPEN_INTERNALS_EXPORT miopenStatus_t CosineSimilarityForward(Handle& handle,
+                                                               const TensorDescriptor& input1Desc,
+                                                               ConstData_t input1,
+                                                               const TensorDescriptor& input2Desc,
+                                                               ConstData_t input2,
+                                                               const TensorDescriptor& outputDesc,
+                                                               Data_t output,
+                                                               uint32_t dim,
+                                                               float eps);
+
+} // namespace cosinesimilarity
+
+} // namespace miopen

--- a/src/include/miopen/cosinesimilarity/invoke_params.hpp
+++ b/src/include/miopen/cosinesimilarity/invoke_params.hpp
@@ -75,7 +75,7 @@ struct BwdInvokeParams : public miopen::InvokeParams
 
     std::size_t GetWorkspaceSize() const { return 0; }
     Data_t GetWorkspace() const { return nullptr; }
-}
+};
 
 } // namespace cosinesimilarity
 

--- a/src/include/miopen/cosinesimilarity/invoke_params.hpp
+++ b/src/include/miopen/cosinesimilarity/invoke_params.hpp
@@ -53,6 +53,30 @@ struct FwdInvokeParams : public miopen::InvokeParams
     Data_t GetWorkspace() const { return nullptr; }
 };
 
+struct BwdInvokeParams : public miopen::InvokeParams
+{
+    BwdInvokeParams() = default;
+
+    const TensorDescriptor* input1Desc     = nullptr;
+    const TensorDescriptor* input2Desc     = nullptr;
+    const TensorDescriptor* outputGradDesc = nullptr;
+    const TensorDescriptor* input1GradDesc = nullptr;
+    const TensorDescriptor* input2GradDesc = nullptr;
+
+    ConstData_t input1         = nullptr;
+    ConstData_t input2         = nullptr;
+    ConstData_t outputGrad     = nullptr;
+    ConstData_t input1Grad     = nullptr;
+    ConstData_t input2Grad     = nullptr;
+    uint32_t dim               = 0;
+    float eps                  = 1e-8f;
+    Data_t workspace           = nullptr;
+    std::size_t workspace_size = 0;
+
+    std::size_t GetWorkspaceSize() const { return 0; }
+    Data_t GetWorkspace() const { return nullptr; }
+}
+
 } // namespace cosinesimilarity
 
 } // namespace miopen

--- a/src/include/miopen/cosinesimilarity/invoke_params.hpp
+++ b/src/include/miopen/cosinesimilarity/invoke_params.hpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <miopen/common.hpp>
+#include <miopen/invoke_params.hpp>
+#include <miopen/tensor.hpp>
+
+namespace miopen {
+
+namespace cosinesimilarity {
+
+struct FwdInvokeParams : public miopen::InvokeParams
+{
+    FwdInvokeParams() = default;
+
+    const TensorDescriptor* input1Desc = nullptr;
+    const TensorDescriptor* input2Desc = nullptr;
+    const TensorDescriptor* outputDesc = nullptr;
+
+    ConstData_t input1 = nullptr;
+    ConstData_t input2 = nullptr;
+    ConstData_t output = nullptr;
+    uint32_t dim       = 0;
+    float eps          = 1e-8f;
+
+    std::size_t GetWorkspaceSize() const { return 0; }
+    Data_t GetWorkspace() const { return nullptr; }
+};
+
+} // namespace cosinesimilarity
+
+} // namespace miopen

--- a/src/include/miopen/cosinesimilarity/problem_description.hpp
+++ b/src/include/miopen/cosinesimilarity/problem_description.hpp
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#pragma once
+
+#include <miopen/errors.hpp>
+#include <miopen/miopen.h>
+#include <miopen/problem_description_base.hpp>
+#include <miopen/tensor.hpp>
+
+namespace miopen {
+
+struct NetworkConfig;
+
+namespace cosinesimilarity {
+
+struct FwdProblemDescription : ProblemDescriptionBase
+{
+    FwdProblemDescription(const TensorDescriptor& input1Desc_,
+                          const TensorDescriptor& input2Desc_,
+                          const TensorDescriptor& outputDesc_,
+                          uint32_t dim_,
+                          float eps_)
+        : input1Desc(input1Desc_),
+          input2Desc(input2Desc_),
+          outputDesc(outputDesc_),
+          dim(dim_),
+          eps(eps_)
+    {
+        if(!IsSameType())
+        {
+            MIOPEN_THROW(miopenStatusBadParm, "Input and output tensor types do not match");
+        }
+    }
+
+    const TensorDescriptor& GetInput1Desc() const { return input1Desc; }
+    const TensorDescriptor& GetInput2Desc() const { return input2Desc; }
+    const TensorDescriptor& GetOutputDesc() const { return outputDesc; }
+
+    bool IsSameType() const
+    {
+        return input1Desc.GetType() == input2Desc.GetType() &&
+               input1Desc.GetType() == outputDesc.GetType();
+    }
+
+    // bool isAllContiguous() const
+    //{
+    //    return inputDesc.IsContiguous() && outputGradDesc.IsContiguous() &&
+    //           weightGradDesc.IsContiguous();
+    //}
+
+    NetworkConfig MakeNetworkConfig() const override;
+
+protected:
+    TensorDescriptor input1Desc;
+    TensorDescriptor input2Desc;
+    TensorDescriptor outputDesc;
+
+    uint32_t dim;
+    float eps;
+};
+
+} // namespace cosinesimilarity
+
+} // namespace miopen

--- a/src/include/miopen/cosinesimilarity/problem_description.hpp
+++ b/src/include/miopen/cosinesimilarity/problem_description.hpp
@@ -65,18 +65,62 @@ struct FwdProblemDescription : ProblemDescriptionBase
                input1Desc.GetType() == outputDesc.GetType();
     }
 
-    // bool isAllContiguous() const
-    //{
-    //    return inputDesc.IsContiguous() && outputGradDesc.IsContiguous() &&
-    //           weightGradDesc.IsContiguous();
-    //}
-
     NetworkConfig MakeNetworkConfig() const override;
 
 protected:
     TensorDescriptor input1Desc;
     TensorDescriptor input2Desc;
     TensorDescriptor outputDesc;
+
+    uint32_t dim;
+    float eps;
+};
+
+struct BwdProblemDescription : ProblemDescriptionBase
+{
+    BwdProblemDescription(const TensorDescriptor& input1Desc_,
+                          const TensorDescriptor& input2Desc_,
+                          const TensorDescriptor& outputGradDesc_,
+                          const TensorDescriptor& input1GradDesc_,
+                          const TensorDescriptor& input2GradDesc_,
+                          uint32_t dim_,
+                          float eps_)
+        : input1Desc(input1Desc_),
+          input2Desc(input2Desc_),
+          outputGradDesc(outputGradDesc_),
+          input1GradDesc(input1GradDesc_),
+          input2GradDesc(input2GradDesc_),
+          dim(dim_),
+          eps(eps_)
+    {
+        if(!IsSameType())
+        {
+            MIOPEN_THROW(miopenStatusBadParm, "Input and output tensor types do not match");
+        }
+    }
+
+    const TensorDescriptor& GetInput1Desc() const { return input1Desc; }
+    const TensorDescriptor& GetInput2Desc() const { return input2Desc; }
+    const TensorDescriptor& GetOutputGradDesc() const { return outputGradDesc; }
+    const TensorDescriptor& GetInput1GradDesc() const { return input1GradDesc; }
+    const TensorDescriptor& GetInput2GradDesc() const { return input2GradDesc; }
+
+    bool IsSameType() const
+    {
+        return input1Desc.GetType() == input2Desc.GetType() &&
+               input1Desc.GetType() == outputGradDesc.GetType() &&
+               input1Desc.GetType() == input1GradDesc.GetType() &&
+               input1Desc.GetType() == input2GradDesc.GetType();
+    }
+
+    NetworkConfig MakeNetworkConfig() const override;
+
+protected:
+    TensorDescriptor input1Desc;
+    TensorDescriptor input2Desc;
+    TensorDescriptor outputGradDesc;
+    TensorDescriptor input1GradDesc;
+    TensorDescriptor input2GradDesc;
 
     uint32_t dim;
     float eps;

--- a/src/include/miopen/cosinesimilarity/problem_description.hpp
+++ b/src/include/miopen/cosinesimilarity/problem_description.hpp
@@ -49,6 +49,12 @@ struct FwdProblemDescription : ProblemDescriptionBase
           dim(dim_),
           eps(eps_)
     {
+        if(input1Desc.GetLengths() != input2Desc.GetLengths())
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "Input1 and input2 tensor dimension lengths do not match.");
+        }
+
         if(!IsSameType())
         {
             MIOPEN_THROW(miopenStatusBadParm, "Input and output tensor types do not match");
@@ -58,6 +64,7 @@ struct FwdProblemDescription : ProblemDescriptionBase
     const TensorDescriptor& GetInput1Desc() const { return input1Desc; }
     const TensorDescriptor& GetInput2Desc() const { return input2Desc; }
     const TensorDescriptor& GetOutputDesc() const { return outputDesc; }
+    uint32_t GetDim() const { return dim; }
 
     bool IsSameType() const
     {
@@ -93,6 +100,12 @@ struct BwdProblemDescription : ProblemDescriptionBase
           dim(dim_),
           eps(eps_)
     {
+        if(input1Desc.GetLengths() != input2Desc.GetLengths())
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "Input1 and input2 tensor dimension lengths do not match.");
+        }
+
         if(!IsSameType())
         {
             MIOPEN_THROW(miopenStatusBadParm, "Input and output tensor types do not match");

--- a/src/include/miopen/cosinesimilarity/solvers.hpp
+++ b/src/include/miopen/cosinesimilarity/solvers.hpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#pragma once
+
+#include <miopen/cosinesimilarity/problem_description.hpp>
+#include <miopen/solver.hpp>
+
+namespace miopen {
+
+namespace solver {
+
+namespace cosinesimilarity {
+
+using CosineSimilarityForwardSolverBase =
+    NonTunableSolverBase<ExecutionContext, miopen::cosinesimilarity::FwdProblemDescription>;
+
+struct CosineSimilarityForward final : CosineSimilarityForwardSolverBase
+{
+    const std::string& SolverDbId() const override
+    {
+        return GetSolverDbId<CosineSimilarityForward>();
+    }
+
+    bool
+    IsApplicable(const ExecutionContext& context,
+                 const miopen::cosinesimilarity::FwdProblemDescription& problem) const override;
+
+    ConvSolution
+    GetSolution(const ExecutionContext& context,
+                const miopen::cosinesimilarity::FwdProblemDescription& problem) const override;
+};
+
+} // namespace cosinesimilarity
+
+} // namespace solver
+
+} // namespace miopen

--- a/src/include/miopen/cosinesimilarity/solvers.hpp
+++ b/src/include/miopen/cosinesimilarity/solvers.hpp
@@ -53,6 +53,25 @@ struct CosineSimilarityForward final : CosineSimilarityForwardSolverBase
                 const miopen::cosinesimilarity::FwdProblemDescription& problem) const override;
 };
 
+using CosineSimilarityBackwardSolverBase =
+    NonTunableSolverBase<ExecutionContext, miopen::cosinesimilarity::BwdProblemDescription>;
+
+struct CosineSimilarityBackward final : CosineSimilarityBackwardSolverBase
+{
+    const std::string& SolverDbId() const override
+    {
+        return GetSolverDbId<CosineSimilarityBackward>();
+    }
+
+    bool
+    IsApplicable(const ExecutionContext& context,
+                 const miopen::cosinesimilarity::BwdProblemDescription& problem) const override;
+
+    ConvSolution
+    GetSolution(const ExecutionContext& context,
+                const miopen::cosinesimilarity::BwdProblemDescription& problem) const override;
+};
+
 } // namespace cosinesimilarity
 
 } // namespace solver

--- a/src/include/miopen/cosinesimilarity/solvers.hpp
+++ b/src/include/miopen/cosinesimilarity/solvers.hpp
@@ -45,6 +45,10 @@ struct CosineSimilarityForward final : CosineSimilarityForwardSolverBase
     }
 
     bool
+    IsImprovementOverROCm(const ExecutionContext& context,
+                          const miopen::cosinesimilarity::FwdProblemDescription& problem) const;
+
+    bool
     IsApplicable(const ExecutionContext& context,
                  const miopen::cosinesimilarity::FwdProblemDescription& problem) const override;
 
@@ -62,6 +66,10 @@ struct CosineSimilarityBackward final : CosineSimilarityBackwardSolverBase
     {
         return GetSolverDbId<CosineSimilarityBackward>();
     }
+
+    bool
+    IsImprovementOverROCm(const ExecutionContext& context,
+                          const miopen::cosinesimilarity::BwdProblemDescription& problem) const;
 
     bool
     IsApplicable(const ExecutionContext& context,

--- a/src/include/miopen/solver_id.hpp
+++ b/src/include/miopen/solver_id.hpp
@@ -64,7 +64,8 @@ enum class Primitive
     ReLU,
     Kthvalue,
     SoftMarginLoss,
-    MultiMarginLoss
+    MultiMarginLoss,
+    CosineSimilarity
 };
 
 struct MIOPEN_INTERNALS_EXPORT Id

--- a/src/kernels/MIOpenCosineSimilarity.cpp
+++ b/src/kernels/MIOpenCosineSimilarity.cpp
@@ -125,12 +125,12 @@ __device__ void CosineSimilarityBackwardKernel(const TIO* input1,
     xn = xn > eps ? sqrt(xn) : sqrt(eps);
     yn = yn > eps ? sqrt(yn) : sqrt(eps);
 
+    out_layout.layout[dim]   = 0;
     TIO output               = output_grad[output_grad_tv.get_tensor_view_idx(out_layout)];
     FLOAT_ACCUM scale        = CVT_FLOAT2ACCUM(output) / (xn * yn);
     FLOAT_ACCUM axpy_scale_x = -scale * xy / (xn * xn);
     FLOAT_ACCUM axpy_scale_y = -scale * xy / (yn * yn);
 
-    out_layout.layout[dim] = 0;
     for(size_t k = 0; k < input1_tv.size[dim]; ++k)
     {
         TIO x = input1[input1_tv.get_tensor_view_idx(out_layout)];

--- a/src/kernels/MIOpenCosineSimilarity.cpp
+++ b/src/kernels/MIOpenCosineSimilarity.cpp
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#endif
+
+#include "float_types.h"
+#include "hip_atomic.hpp"
+#include "tensor_view.hpp"
+
+template <typename TIO>
+__device__ void CosineSimilarityForwardKernel(const TIO* input1,
+                                              const TIO* input2,
+                                              TIO* output,
+                                              uint64_t output_size,
+                                              uint32_t dim,
+                                              float eps,
+                                              tensor_view_t<5> input1_tv,
+                                              tensor_view_t<5> input2_tv,
+                                              tensor_view_t<5> output_tv)
+{
+    size_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if(gid >= output_size)
+        return;
+
+    tensor_layout_t<5> out_layout(output_tv, gid);
+
+    TIO xy = 0;
+    TIO xn = 0;
+    TIO yn = 0;
+
+    for(size_t k = 0; k < input1_tv.size[dim]; ++k)
+    {
+        TIO x = input1[input1_tv.get_tensor_view_idx(out_layout)];
+        TIO y = input2[input2_tv.get_tensor_view_idx(out_layout)];
+
+        xy += x * y;
+        xn += x * x;
+        yn += y * y;
+
+        out_layout.layout[dim]++;
+    }
+
+    xn = xn > eps ? xn : eps;
+    yn = yn > eps ? yn : eps;
+
+    output[output_tv.get_tensor_view_idx(out_layout)] = xy / sqrtf(xn * yn);
+}
+
+extern "C" __global__ void CosineSimilarityForward(const IO_TYPE* input1,
+                                                   const IO_TYPE* input2,
+                                                   IO_TYPE* output,
+                                                   uint64_t output_size,
+                                                   uint32_t dim,
+                                                   float eps,
+                                                   tensor_view_t<5> input1_tv,
+                                                   tensor_view_t<5> input2_tv,
+                                                   tensor_view_t<5> output_tv)
+{
+    CosineSimilarityForwardKernel<IO_TYPE>(
+        input1, input2, output, output_size, dim, eps, input1_tv, input2_tv, output_tv);
+}
+
+template <typename TIO>
+__device__ void CosineSimilarityBackwardKernel(const TIO* input1,
+                                               const TIO* input2,
+                                               const TIO* output_grad,
+                                               TIO* input1_grad,
+                                               TIO* input2_grad,
+                                               uint64_t output_size,
+                                               uint32_t dim,
+                                               float eps,
+                                               tensor_view_t<5> input1_tv,
+                                               tensor_view_t<5> input2_tv,
+                                               tensor_view_t<5> output_grad_tv,
+                                               tensor_view_t<5> input1_grad_tv,
+                                               tensor_view_t<5> input2_grad_tv)
+{
+    size_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if(gid >= output_size)
+        return;
+
+    tensor_layout_t<5> out_layout(output_grad_tv, gid);
+
+    TIO xy = 0;
+    TIO xn = 0;
+    TIO yn = 0;
+
+    for(size_t k = 0; k < input1_tv.size[dim]; ++k)
+    {
+        TIO x = input1[input1_tv.get_tensor_view_idx(out_layout)];
+        TIO y = input2[input2_tv.get_tensor_view_idx(out_layout)];
+
+        xy += x * y;
+        xn += x * x;
+        yn += y * y;
+
+        out_layout.layout[dim]++;
+    }
+
+    xn = xn > eps ? sqrt(xn) : sqrt(eps);
+    yn = yn > eps ? sqrt(yn) : sqrt(eps);
+
+    TIO output       = output_grad[output_grad_tv.get_tensor_view_idx(out_layout)];
+    TIO scale        = output / (xn * yn);
+    TIO axpy_scale_x = -scale * xy / (xn * xn);
+    TIO axpy_scale_y = -scale * xy / (yn * yn);
+
+    out_layout.layout[dim] = 0;
+    for(size_t k = 0; k < input1_tv.size[dim]; ++k)
+    {
+        TIO x = input1[input1_tv.get_tensor_view_idx(out_layout)];
+        TIO y = input2[input2_tv.get_tensor_view_idx(out_layout)];
+
+        if(input1_grad)
+        {
+            input1_grad[input1_grad_tv.get_tensor_view_idx(out_layout)] =
+                scale * y + axpy_scale_x * x;
+        }
+        if(input2_grad)
+        {
+            input2_grad[input2_grad_tv.get_tensor_view_idx(out_layout)] =
+                scale * x + axpy_scale_y * y;
+        }
+
+        out_layout.layout[dim]++;
+    }
+}
+
+extern "C" __global__ void CosineSimilarityBackward(const IO_TYPE* input1,
+                                                    const IO_TYPE* input2,
+                                                    const IO_TYPE* output_grad,
+                                                    IO_TYPE* input1_grad,
+                                                    IO_TYPE* input2_grad,
+                                                    uint64_t output_size,
+                                                    uint32_t dim,
+                                                    float eps,
+                                                    tensor_view_t<5> input1_tv,
+                                                    tensor_view_t<5> input2_tv,
+                                                    tensor_view_t<5> output_grad_tv,
+                                                    tensor_view_t<5> input1_grad_tv,
+                                                    tensor_view_t<5> input2_grad_tv)
+{
+    CosineSimilarityBackwardKernel<IO_TYPE>(input1,
+                                            input2,
+                                            output_grad,
+                                            input1_grad,
+                                            input2_grad,
+                                            output_size,
+                                            dim,
+                                            eps,
+                                            input1_tv,
+                                            input2_tv,
+                                            output_grad_tv,
+                                            input1_grad_tv,
+                                            input2_grad_tv);
+}

--- a/src/kernels/tensor_view.hpp
+++ b/src/kernels/tensor_view.hpp
@@ -46,6 +46,29 @@ struct tensor_view_t
         }
         return idx;
     }
+
+    constexpr auto unsqueeze(uint32_t dim)
+    {
+        tensor_view_t<N + 1> new_view;
+
+        for(auto i = 0; i < dim; i++)
+        {
+            new_view.size[i]   = size[i];
+            new_view.stride[i] = stride[i];
+        }
+
+        new_view.size[dim]   = 1;
+        new_view.stride[dim] = size[dim] * stride[dim];
+
+        for(auto i = dim; i < N; i++)
+        {
+            new_view.size[i + 1]   = size[i];
+            new_view.stride[i + 1] = stride[i];
+        }
+
+        return new_view;
+    }
+
     uint64_t stride[N];
     uint64_t size[N];
 };

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -24,6 +24,7 @@
  *
  *******************************************************************************/
 
+#include "miopen/cosinesimilarity/solvers.hpp"
 #include <miopen/activ/solvers.hpp>
 #include <miopen/adam/solvers.hpp>
 #include <miopen/batchnorm/solvers.hpp>
@@ -715,6 +716,10 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
              multimarginloss::MultiMarginLossForward{}.SolverDbId());
 
     Register(registry, ++id, Primitive::Mha, mha::MhaCKFlashAttentionV2Forward{}.SolverDbId());
+    Register(registry,
+             ++id,
+             Primitive::CosineSimilarity,
+             cosinesimilarity::CosineSimilarityForward{}.SolverDbId());
     // IMPORTANT: New solvers should be added to the end of the function, and don't leave a white
     // space between this comment and the newly registered solver(s)!
 }

--- a/src/solver/cosinesimilarity/backward_cosinesimilarity.cpp
+++ b/src/solver/cosinesimilarity/backward_cosinesimilarity.cpp
@@ -47,13 +47,30 @@ namespace solver {
 
 namespace cosinesimilarity {
 
-bool CosineSimilarityBackward::IsApplicable(
+bool CosineSimilarityBackward::IsImprovementOverROCm(
     const ExecutionContext& /*context*/,
+    const miopen::cosinesimilarity::BwdProblemDescription& problem) const
+{
+    if(problem.GetOutputGradDesc().GetElementSize() < 20000)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool CosineSimilarityBackward::IsApplicable(
+    const ExecutionContext& context,
     const miopen::cosinesimilarity::BwdProblemDescription& problem) const
 {
     if(!(problem.GetInput1Desc().GetType() == miopenFloat ||
          problem.GetInput1Desc().GetType() == miopenHalf ||
          problem.GetInput1Desc().GetType() == miopenBFloat16))
+    {
+        return false;
+    }
+
+    if(!IsImprovementOverROCm(context, problem))
     {
         return false;
     }

--- a/src/solver/cosinesimilarity/forward_cosinesimilarity.cpp
+++ b/src/solver/cosinesimilarity/forward_cosinesimilarity.cpp
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/cosinesimilarity/invoke_params.hpp>
+#include <miopen/cosinesimilarity/problem_description.hpp>
+#include <miopen/cosinesimilarity/solvers.hpp>
+#include <miopen/datatype.hpp>
+#include <miopen/errors.hpp>
+#include <miopen/hipoc_kernel.hpp>
+#include <miopen/kernel_build_params.hpp>
+#include <miopen/kernel_info.hpp>
+#include <miopen/miopen.h>
+#include <miopen/mlo_internal.hpp>
+#include <miopen/tensor_view_utils.hpp>
+
+#include <cstddef>
+#include <vector>
+
+#define LOCAL_SIZE 256
+
+namespace miopen {
+
+namespace solver {
+
+namespace cosinesimilarity {
+
+bool CosineSimilarityForward::IsApplicable(
+    const ExecutionContext& /*context*/,
+    const miopen::cosinesimilarity::FwdProblemDescription& problem) const
+{
+    if(!(problem.GetInput1Desc().GetType() == miopenFloat ||
+         problem.GetInput1Desc().GetType() == miopenHalf ||
+         problem.GetInput1Desc().GetType() == miopenBFloat16))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+ConvSolution CosineSimilarityForward::GetSolution(
+    const ExecutionContext& context,
+    const miopen::cosinesimilarity::FwdProblemDescription& problem) const
+{
+    std::ignore = context;
+
+    auto result = ConvSolution{miopenStatusSuccess};
+
+    auto dtype        = problem.GetInput1Desc().GetType();
+    auto io_dtype     = miopen::GetDataType(problem.GetInput1Desc().GetType());
+    auto output_numel = problem.GetOutputDesc().GetElementSize();
+
+    size_t xlocalsize = LOCAL_SIZE;
+    size_t xgridsize  = AlignUp(output_numel, xlocalsize);
+    size_t ylocalsize = 1;
+    size_t ygridsize  = 1;
+    size_t zlocalsize = 1;
+    size_t zgridsize  = 1;
+
+    auto kernel = KernelInfo{};
+
+    kernel.kernel_file = "MIOpenCosineSimilarity.cpp";
+    kernel.kernel_name = "CosineSimilarityForward";
+
+    const auto build_params =
+        KernelBuildParameters{{"MIOPEN_USE_FP16", static_cast<int>(dtype == miopenHalf)},
+                              {"MIOPEN_USE_FP32", static_cast<int>(dtype == miopenFloat)},
+                              {"MIOPEN_USE_BFP16", static_cast<int>(dtype == miopenBFloat16)},
+                              {"IO_TYPE", io_dtype == "bfloat16" ? "ushort" : io_dtype}};
+
+    kernel.comp_options = build_params.GenerateFor(kbp::HIP{});
+
+    kernel.l_wk.push_back(xlocalsize);
+    kernel.l_wk.push_back(ylocalsize);
+    kernel.l_wk.push_back(zlocalsize);
+    kernel.g_wk.push_back(xgridsize);
+    kernel.g_wk.push_back(ygridsize);
+    kernel.g_wk.push_back(zgridsize);
+
+    result.construction_params.push_back(kernel);
+
+    result.invoker_factory = [output_numel](const std::vector<Kernel>& kernels) {
+        return [=](const Handle& handle_, const AnyInvokeParams& raw_params) {
+            decltype(auto) kernel = handle_.Run(kernels.front());
+            decltype(auto) params = raw_params.CastTo<miopen::cosinesimilarity::FwdInvokeParams>();
+
+            tensor_view_t<5> input1_tv = get_inner_expanded_tv<5>(miopen::deref(params.input1Desc));
+            tensor_view_t<5> input2_tv = get_inner_expanded_tv<5>(miopen::deref(params.input2Desc));
+            tensor_view_t<5> output_tv = get_inner_expanded_tv<5>(miopen::deref(params.outputDesc));
+
+            kernel(params.input1,
+                   params.input2,
+                   params.output,
+                   output_numel,
+                   params.dim,
+                   params.eps,
+                   input1_tv,
+                   input2_tv,
+                   output_tv);
+        };
+    };
+
+    return result;
+}
+
+} // namespace cosinesimilarity
+
+} // namespace solver
+
+} // namespace miopen

--- a/src/solver/cosinesimilarity/forward_cosinesimilarity.cpp
+++ b/src/solver/cosinesimilarity/forward_cosinesimilarity.cpp
@@ -47,13 +47,30 @@ namespace solver {
 
 namespace cosinesimilarity {
 
-bool CosineSimilarityForward::IsApplicable(
+bool CosineSimilarityForward::IsImprovementOverROCm(
     const ExecutionContext& /*context*/,
+    const miopen::cosinesimilarity::FwdProblemDescription& problem) const
+{
+    if(problem.GetOutputDesc().GetElementSize() < 20000)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool CosineSimilarityForward::IsApplicable(
+    const ExecutionContext& context,
     const miopen::cosinesimilarity::FwdProblemDescription& problem) const
 {
     if(!(problem.GetInput1Desc().GetType() == miopenFloat ||
          problem.GetInput1Desc().GetType() == miopenHalf ||
          problem.GetInput1Desc().GetType() == miopenBFloat16))
+    {
+        return false;
+    }
+
+    if(!IsImprovementOverROCm(context, problem))
     {
         return false;
     }

--- a/test/cpu_cosinesimilarity.hpp
+++ b/test/cpu_cosinesimilarity.hpp
@@ -111,12 +111,12 @@ void cpu_cosinesimilarity_backward(const tensor<T>& input1,
         xn = xn > eps ? sqrt(xn) : sqrt(eps);
         yn = yn > eps ? sqrt(yn) : sqrt(eps);
 
-        T output            = output_grad[output_grad_tv.get_tensor_view_idx(out_layout)];
-        double scale        = output / (xn * yn);
-        double axpy_scale_x = -scale * xy / (xn * yn);
-        double axpy_scale_y = -scale * xy / (yn * yn);
-
         out_layout.layout[dim] = 0;
+        T output               = output_grad[output_grad_tv.get_tensor_view_idx(out_layout)];
+        double scale           = output / (xn * yn);
+        double axpy_scale_x    = -scale * xy / (xn * xn);
+        double axpy_scale_y    = -scale * xy / (yn * yn);
+
         for(size_t k = 0; k < input1_tv.size[dim]; ++k)
         {
             T x = input1[input1_tv.get_tensor_view_idx(out_layout)];

--- a/test/cpu_cosinesimilarity.hpp
+++ b/test/cpu_cosinesimilarity.hpp
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#pragma once
+
+#include <miopen/miopen.h>
+#include <miopen/tensor_view_utils.hpp>
+
+#include "tensor_holder.hpp"
+#include "tensor_view.hpp"
+
+#include <cstddef>
+
+template <class T>
+void cpu_cosinesimilarity_forward(
+    const tensor<T>& input1, const tensor<T>& input2, tensor<T>& output, uint32_t dim, float eps)
+{
+    auto out_sz                   = output.desc.GetElementSize();
+    tensor_view_t<5> input1_tv    = miopen::get_inner_expanded_tv<5>(input1.desc);
+    tensor_view_t<5> input2_tv    = miopen::get_inner_expanded_tv<5>(input2.desc);
+    tensor_view_t<4> output_tv_4d = miopen::get_inner_expanded_tv<4>(output.desc);
+    tensor_view_t<5> output_tv    = output_tv_4d.unsqueeze(dim);
+
+    for(auto o = 0; o < out_sz; o++)
+    {
+        double xy = 0;
+        double xn = 0;
+        double yn = 0;
+
+        tensor_layout_t<5> out_layout(output_tv, o);
+
+        for(size_t k = 0; k < input1_tv.size[dim]; ++k)
+        {
+            T x = input1[input1_tv.get_tensor_view_idx(out_layout)];
+            T y = input2[input2_tv.get_tensor_view_idx(out_layout)];
+
+            xy += x * y;
+            xn += x * x;
+            yn += y * y;
+
+            out_layout.layout[dim]++;
+        }
+
+        xn = xn > eps ? xn : eps;
+        yn = yn > eps ? yn : eps;
+
+        out_layout.layout[dim]                            = 0;
+        output[output_tv.get_tensor_view_idx(out_layout)] = xy / sqrt(xn * yn);
+    }
+}
+
+template <class T>
+void cpu_cosinesimilarity_backward(const tensor<T>& input1,
+                                   const tensor<T>& input2,
+                                   const tensor<T>& output_grad,
+                                   tensor<T>& input1_grad,
+                                   tensor<T>& input2_grad,
+                                   uint32_t dim,
+                                   float eps)
+{
+    auto out_sz                        = output_grad.desc.GetElementSize();
+    tensor_view_t<5> input1_tv         = miopen::get_inner_expanded_tv<5>(input1.desc);
+    tensor_view_t<5> input2_tv         = miopen::get_inner_expanded_tv<5>(input2.desc);
+    tensor_view_t<5> input1_grad_tv    = miopen::get_inner_expanded_tv<5>(input1_grad.desc);
+    tensor_view_t<5> input2_grad_tv    = miopen::get_inner_expanded_tv<5>(input2_grad.desc);
+    tensor_view_t<4> output_grad_tv_4d = miopen::get_inner_expanded_tv<4>(output_grad.desc);
+    tensor_view_t<5> output_grad_tv    = output_grad_tv_4d.unsqueeze(dim);
+
+    for(auto o = 0; o < out_sz; o++)
+    {
+        tensor_layout_t<5> out_layout(output_grad_tv, o);
+
+        double xy = 0;
+        double xn = 0;
+        double yn = 0;
+
+        for(size_t k = 0; k < input1_tv.size[dim]; ++k)
+        {
+            T x = input1[input1_tv.get_tensor_view_idx(out_layout)];
+            T y = input2[input2_tv.get_tensor_view_idx(out_layout)];
+
+            xy += x * y;
+            xn += x * x;
+            yn += y * y;
+
+            out_layout.layout[dim]++;
+        }
+
+        xn = xn > eps ? sqrt(xn) : sqrt(eps);
+        yn = yn > eps ? sqrt(yn) : sqrt(eps);
+
+        T output            = output_grad[output_grad_tv.get_tensor_view_idx(out_layout)];
+        double scale        = output / (xn * yn);
+        double axpy_scale_x = -scale * xy / (xn * yn);
+        double axpy_scale_y = -scale * xy / (yn * yn);
+
+        out_layout.layout[dim] = 0;
+        for(size_t k = 0; k < input1_tv.size[dim]; ++k)
+        {
+            T x = input1[input1_tv.get_tensor_view_idx(out_layout)];
+            T y = input2[input2_tv.get_tensor_view_idx(out_layout)];
+
+            input1_grad[input1_grad_tv.get_tensor_view_idx(out_layout)] =
+                scale * y + axpy_scale_x * x;
+            input2_grad[input2_grad_tv.get_tensor_view_idx(out_layout)] =
+                scale * x + axpy_scale_y * y;
+
+            out_layout.layout[dim]++;
+        }
+    }
+}

--- a/test/gtest/cosinesimilarity.cpp
+++ b/test/gtest/cosinesimilarity.cpp
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "cosinesimilarity.hpp"
+using float16 = half_float::half;
+
+namespace cosinesimilarity {
+
+using GPU_CosineSimilarity_fwd_FP32  = CosineSimilarityFwdTest<float>;
+using GPU_CosineSimilarity_fwd_FP16  = CosineSimilarityFwdTest<float16>;
+using GPU_CosineSimilarity_fwd_BFP16 = CosineSimilarityFwdTest<bfloat16>;
+
+using GPU_CosineSimilarity_bwd_FP32  = CosineSimilarityBwdTest<float>;
+using GPU_CosineSimilarity_bwd_FP16  = CosineSimilarityBwdTest<float16>;
+using GPU_CosineSimilarity_bwd_BFP16 = CosineSimilarityBwdTest<bfloat16>;
+
+} // namespace cosinesimilarity
+using namespace cosinesimilarity;
+
+TEST_P(GPU_CosineSimilarity_fwd_FP32, Test)
+{
+    RunTest();
+    Verify();
+};
+
+TEST_P(GPU_CosineSimilarity_fwd_FP16, Test)
+{
+    RunTest();
+    Verify();
+};
+
+TEST_P(GPU_CosineSimilarity_fwd_BFP16, Test)
+{
+    RunTest();
+    Verify();
+};
+
+TEST_P(GPU_CosineSimilarity_bwd_FP32, Test)
+{
+    RunTest();
+    Verify();
+};
+
+TEST_P(GPU_CosineSimilarity_bwd_FP16, Test)
+{
+    RunTest();
+    Verify();
+};
+
+TEST_P(GPU_CosineSimilarity_bwd_BFP16, Test)
+{
+    RunTest();
+    Verify();
+};
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_CosineSimilarity_fwd_FP32,
+                         testing::ValuesIn(GenFullTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_CosineSimilarity_fwd_FP16,
+                         testing::ValuesIn(GenFullTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_CosineSimilarity_fwd_BFP16,
+                         testing::ValuesIn(GenFullTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_CosineSimilarity_bwd_FP32,
+                         testing::ValuesIn(GenFullTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_CosineSimilarity_bwd_FP16,
+                         testing::ValuesIn(GenFullTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_CosineSimilarity_bwd_BFP16,
+                         testing::ValuesIn(GenFullTestCases()));

--- a/test/gtest/cosinesimilarity.hpp
+++ b/test/gtest/cosinesimilarity.hpp
@@ -1,0 +1,323 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "cpu_cosinesimilarity.hpp"
+#include "get_handle.hpp"
+#include "tensor_holder.hpp"
+#include "verify.hpp"
+#include "random.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <limits>
+#include <unordered_map>
+#include <vector>
+
+#include <miopen/allocator.hpp>
+#include <miopen/cosinesimilarity.hpp>
+#include <miopen/miopen.h>
+
+struct CosineSimilarityTestCase
+{
+    std::vector<size_t> input1_dim;
+    std::vector<size_t> input2_dim;
+    uint32_t dim;
+    float eps;
+    bool isContiguous;
+
+    friend std::ostream& operator<<(std::ostream& os, const CosineSimilarityTestCase& tc)
+    {
+        os << "Input1 dims: ";
+        for(auto dim_sz : tc.input1_dim)
+        {
+            os << dim_sz << " ";
+        }
+        os << "Input2 dims: ";
+        for(auto dim_sz : tc.input2_dim)
+        {
+            os << dim_sz << " ";
+        }
+        return os << " contiguous: " << tc.isContiguous << " dim: " << tc.dim << " eps: " << tc.eps;
+    }
+
+    CosineSimilarityTestCase() {}
+
+    CosineSimilarityTestCase(std::vector<size_t> input1_dims_,
+                             std::vector<size_t> input2_dims_,
+                             uint32_t dim_,
+                             float eps_,
+                             bool cont_)
+        : input1_dim(input1_dims_),
+          input2_dim(input2_dims_),
+          dim(dim_),
+          eps(eps_),
+          isContiguous(cont_)
+    {
+    }
+
+    std::vector<size_t> ComputeStrides(const std::vector<size_t>& input_dim_) const
+    {
+        std::vector<size_t> inputDim = input_dim_;
+        if(!isContiguous)
+            std::swap(inputDim.front(), inputDim.back());
+        std::vector<size_t> strides(inputDim.size());
+        strides.back() = 1;
+        for(int i = inputDim.size() - 2; i >= 0; --i)
+            strides[i] = strides[i + 1] * inputDim[i + 1];
+        if(!isContiguous)
+            std::swap(strides.front(), strides.back());
+        return strides;
+    }
+};
+
+inline std::vector<CosineSimilarityTestCase> GenFullTestCases()
+{ // n c d h w dim
+    // clang-format off
+    return {
+        {{16, 4}, {16, 4}, 0, 1e-8, true}, // cont small input
+        {{16, 4}, {16, 4}, 0, 1e-8, false}, // non-cont small input
+        {{32, 32, 64}, {32, 32, 64}, 0, 1e-8, true}, // cont medium input
+        {{32, 32, 64}, {32, 32, 64}, 0, 1e-8, false}, // non-cont medium input
+        {{32, 32, 64}, {32, 32, 64}, 1, 1e-8, true}, // cont medium input
+        {{32, 32, 64}, {32, 32, 64}, 1, 1e-8, false}, // non-cont medium input
+        {{1024, 1024}, {1024, 1024}, 0, 1e-8, true}, // cont large input
+        {{1024, 1024}, {1024, 1024}, 0, 1e-8, false}, // non-cont large input
+        {{1024, 1024}, {1024, 1024}, 1, 1e-8, true}, // cont large input
+        {{1024, 1024}, {1024, 1024}, 1, 1e-8, false}, // non-cont large input
+    };
+    // clang-format on
+}
+
+template <typename T>
+struct CosineSimilarityFwdTest : public ::testing::TestWithParam<CosineSimilarityTestCase>
+{
+protected:
+    void SetUp() override
+    {
+        auto&& handle  = get_handle();
+        config         = GetParam();
+        auto gen_value = [](auto...) { return prng::gen_descreet_uniform_sign<T>(1e-2, 100); };
+
+        auto in1_dims    = config.input1_dim;
+        auto in1_strides = config.ComputeStrides(in1_dims);
+        input1           = tensor<T>{in1_dims, in1_strides}.generate(gen_value);
+
+        auto in2_dims    = config.input2_dim;
+        auto in2_strides = config.ComputeStrides(in2_dims);
+        input2           = tensor<T>{in2_dims, in2_strides}.generate(gen_value);
+
+        std::vector<size_t> out_dims;
+        for(int i = 0; i < in1_dims.size(); i++)
+        {
+            if(i != config.dim)
+            {
+                out_dims.push_back(max(in1_dims[i], in2_dims[i]));
+            }
+        }
+        auto out_strides = config.ComputeStrides(out_dims);
+        output           = tensor<T>{out_dims, out_strides};
+        std::fill(output.begin(), output.end(), std::numeric_limits<T>::quiet_NaN());
+
+        ref_output = tensor<T>{out_dims, out_strides};
+        std::fill(ref_output.begin(), ref_output.end(), static_cast<T>(0));
+
+        input1_dev = handle.Write(input1.data);
+        input2_dev = handle.Write(input2.data);
+        output_dev = handle.Write(output.data);
+    }
+
+    void RunTest()
+    {
+        auto&& handle = get_handle();
+
+        miopenStatus_t status;
+
+        cpu_cosinesimilarity_forward(input1, input2, ref_output, config.dim, config.eps);
+        status = miopen::cosinesimilarity::CosineSimilarityForward(handle,
+                                                                   input1.desc,
+                                                                   input1_dev.get(),
+                                                                   input2.desc,
+                                                                   input2_dev.get(),
+                                                                   output.desc,
+                                                                   output_dev.get(),
+                                                                   config.dim,
+                                                                   config.eps);
+
+        ASSERT_EQ(status, miopenStatusSuccess);
+
+        output.data = handle.Read<T>(output_dev, output.data.size());
+    }
+
+    double GetTolerance()
+    {
+        double tolerance = std::numeric_limits<T>::epsilon() * 10;
+        return tolerance;
+    }
+
+    void Verify()
+    {
+        double threshold = GetTolerance();
+        EXPECT_EQ(miopen::range_distance(ref_output), miopen::range_distance(output));
+        auto error = miopen::rms_range(ref_output, output);
+
+        EXPECT_LT(error, threshold * 10) << "Error output beyond tolerance Error: " << error
+                                         << ",  Tolerance: " << threshold * 10;
+    }
+
+    CosineSimilarityTestCase config;
+
+    tensor<T> input1;
+    tensor<T> input2;
+    tensor<T> output;
+
+    tensor<T> ref_output;
+
+    miopen::Allocator::ManageDataPtr input1_dev;
+    miopen::Allocator::ManageDataPtr input2_dev;
+    miopen::Allocator::ManageDataPtr output_dev;
+
+    uint32_t dim;
+    float eps;
+};
+
+template <typename T>
+struct CosineSimilarityBwdTest : public ::testing::TestWithParam<CosineSimilarityTestCase>
+{
+protected:
+    void SetUp() override
+    {
+        auto&& handle  = get_handle();
+        config         = GetParam();
+        auto gen_value = [](auto...) { return prng::gen_descreet_uniform_sign<T>(1e-2, 100); };
+
+        auto in1_dims    = config.input1_dim;
+        auto in1_strides = config.ComputeStrides(in1_dims);
+        input1           = tensor<T>{in1_dims, in1_strides}.generate(gen_value);
+
+        auto in2_dims    = config.input2_dim;
+        auto in2_strides = config.ComputeStrides(in2_dims);
+        input2           = tensor<T>{in2_dims, in2_strides}.generate(gen_value);
+
+        std::vector<size_t> out_dims;
+        for(int i = 0; i < in1_dims.size(); i++)
+        {
+            if(i != config.dim)
+            {
+                out_dims.push_back(max(in1_dims[i], in2_dims[i]));
+            }
+        }
+        auto out_strides = config.ComputeStrides(out_dims);
+        outputGrad       = tensor<T>{out_dims, out_strides}.generate(gen_value);
+
+        input1Grad = tensor<T>{in1_dims, in1_strides};
+        input2Grad = tensor<T>{in2_dims, in2_strides};
+        std::fill(input1Grad.begin(), input1Grad.end(), std::numeric_limits<T>::quiet_NaN());
+        std::fill(input2Grad.begin(), input2Grad.end(), std::numeric_limits<T>::quiet_NaN());
+
+        ref_input1Grad = tensor<T>{in1_dims, in1_strides};
+        std::fill(ref_input1Grad.begin(), ref_input1Grad.end(), static_cast<T>(0));
+        ref_input2Grad = tensor<T>{in2_dims, in2_strides};
+        std::fill(ref_input2Grad.begin(), ref_input2Grad.end(), static_cast<T>(0));
+
+        input1_dev     = handle.Write(input1.data);
+        input2_dev     = handle.Write(input2.data);
+        outputGrad_dev = handle.Write(outputGrad.data);
+        input1Grad_dev = handle.Write(input1Grad.data);
+        input2Grad_dev = handle.Write(input2Grad.data);
+    }
+
+    void RunTest()
+    {
+        auto&& handle = get_handle();
+
+        miopenStatus_t status;
+
+        cpu_cosinesimilarity_backward(
+            input1, input2, outputGrad, ref_input1Grad, ref_input2Grad, config.dim, config.eps);
+        status = miopen::cosinesimilarity::CosineSimilarityBackward(handle,
+                                                                    input1.desc,
+                                                                    input1_dev.get(),
+                                                                    input2.desc,
+                                                                    input2_dev.get(),
+                                                                    outputGrad.desc,
+                                                                    outputGrad_dev.get(),
+                                                                    input1Grad.desc,
+                                                                    input1Grad_dev.get(),
+                                                                    input2Grad.desc,
+                                                                    input2Grad_dev.get(),
+                                                                    config.dim,
+                                                                    config.eps);
+
+        ASSERT_EQ(status, miopenStatusSuccess);
+
+        input1Grad.data = handle.Read<T>(input1Grad_dev, input1Grad.data.size());
+        input2Grad.data = handle.Read<T>(input2Grad_dev, input2Grad.data.size());
+    }
+
+    double GetTolerance()
+    {
+        double tolerance = std::numeric_limits<T>::epsilon() * 10;
+        return tolerance;
+    }
+
+    void Verify()
+    {
+        double threshold = GetTolerance();
+        auto error1      = miopen::rms_range(ref_input1Grad, input1Grad);
+        auto error2      = miopen::rms_range(ref_input2Grad, input2Grad);
+
+        EXPECT_EQ(miopen::range_distance(ref_input1Grad), miopen::range_distance(input1Grad));
+        EXPECT_EQ(miopen::range_distance(ref_input2Grad), miopen::range_distance(input2Grad));
+
+        EXPECT_LT(error1, threshold * 10)
+            << "Error output (input grad 1) beyond tolerance Error: " << error1
+            << ",  Tolerance: " << threshold * 10;
+        EXPECT_LT(error2, threshold * 10)
+            << "Error output (input grad 2) beyond tolerance Error: " << error2
+            << ",  Tolerance: " << threshold * 10;
+    }
+
+    CosineSimilarityTestCase config;
+
+    tensor<T> input1;
+    tensor<T> input2;
+    tensor<T> outputGrad;
+    tensor<T> input1Grad;
+    tensor<T> input2Grad;
+
+    tensor<T> ref_input1Grad;
+    tensor<T> ref_input2Grad;
+
+    miopen::Allocator::ManageDataPtr input1_dev;
+    miopen::Allocator::ManageDataPtr input2_dev;
+    miopen::Allocator::ManageDataPtr outputGrad_dev;
+    miopen::Allocator::ManageDataPtr input1Grad_dev;
+    miopen::Allocator::ManageDataPtr input2Grad_dev;
+
+    uint32_t dim;
+    float eps;
+};

--- a/test/gtest/cosinesimilarity.hpp
+++ b/test/gtest/cosinesimilarity.hpp
@@ -97,16 +97,16 @@ inline std::vector<CosineSimilarityTestCase> GenFullTestCases()
 { // n c d h w dim
     // clang-format off
     return {
-        {{16, 4}, {16, 4}, 0, 1e-8, true}, // cont small input
-        {{16, 4}, {16, 4}, 0, 1e-8, false}, // non-cont small input
-        {{32, 32, 64}, {32, 32, 64}, 0, 1e-8, true}, // cont medium input
-        {{32, 32, 64}, {32, 32, 64}, 0, 1e-8, false}, // non-cont medium input
-        {{32, 32, 64}, {32, 32, 64}, 1, 1e-8, true}, // cont medium input
-        {{32, 32, 64}, {32, 32, 64}, 1, 1e-8, false}, // non-cont medium input
-        {{1024, 1024}, {1024, 1024}, 0, 1e-8, true}, // cont large input
-        {{1024, 1024}, {1024, 1024}, 0, 1e-8, false}, // non-cont large input
-        {{1024, 1024}, {1024, 1024}, 1, 1e-8, true}, // cont large input
-        {{1024, 1024}, {1024, 1024}, 1, 1e-8, false}, // non-cont large input
+        {{256, 128, 256}, {256, 128, 256}, 0, 1e-8, true},
+        {{256, 128, 256}, {256, 128, 256}, 0, 1e-8, false},
+        {{32, 320, 64}, {32, 320, 64}, 0, 1e-8, true},
+        {{32, 320, 64}, {32, 320, 64}, 0, 1e-8, false},
+        {{320, 32, 64}, {320, 32, 64}, 1, 1e-8, true},
+        {{320, 32, 64}, {320, 32, 64}, 1, 1e-8, false},
+        {{32, 1024, 1024}, {32, 1024, 1024}, 0, 1e-8, true},
+        {{32, 1024, 1024}, {32, 1024, 1024}, 0, 1e-8, false},
+        {{32, 1024, 1024}, {32, 1024, 1024}, 1, 1e-8, true},
+        {{32, 1024, 1024}, {32, 1024, 1024}, 1, 1e-8, false},
     };
     // clang-format on
 }


### PR DESCRIPTION
- Add CosineSimilarity operation with forward and backward kernels.
- Add driver and gtest for kernels.
- MIOpen performs better if:
  - Number of output elements exceeds 20000

### Average improvement over ROCm
|   type   |  fwd |  bwd |
|:--------:|:----:|:----:|
| float16  | 1.86 | 2.72 |
| float    | 1.69 | 1.82 |
| bfloat16 | 2.04 | 1.96 |

### Detail Benchmark
<details close>
<summary>float16</summary>
<br>

|       op_name       |  dtype  |     input1     | input2         | contiguous    | direction |   ROCm   | MIOpen   | MIOpen vs ROCm |
|:-------------------:|:-------:|:--------------:|----------------|---------------|:---------:|:--------:|----------|----------------|
| Cosine Similarities | float16 | [100 512 200]  | [100 512 200]  | contiguous    | fwd       |   426253 |   347020 |           1.23 |
| Cosine Similarities | float16 | [100 512 200]  | [100 512 200]  | contiguous    | bwd       |  1462341 |   947513 |           1.54 |
| Cosine Similarities | float16 | [100 1024 200] | [100 1024 200] | contiguous    | fwd       |   798794 |   688528 |           1.16 |
| Cosine Similarities | float16 | [100 1024 200] | [100 1024 200] | contiguous    | bwd       |  2784315 |  1897090 |           1.47 |
| Cosine Similarities | float16 | [48 512 512]   | [48 512 512]   | contiguous    | fwd       |   515276 |   352034 |           1.46 |
| Cosine Similarities | float16 | [48 512 512]   | [48 512 512]   | contiguous    | bwd       |  1786899 |   966217 |           1.85 |
| Cosine Similarities | float16 | [48 512 512]   | [48 512 512]   | noncontiguous | fwd       |  2821500 |  1338300 |           2.11 |
| Cosine Similarities | float16 | [48 512 512]   | [48 512 512]   | noncontiguous | bwd       |  6846559 |  4324440 |           1.58 |
| Cosine Similarities | float16 | [48 1024 512]  | [48 1024 512]  | noncontiguous | fwd       |  5630840 |  3726720 |           1.51 |
| Cosine Similarities | float16 | [48 1024 512]  | [48 1024 512]  | noncontiguous | bwd       | 14110539 | 10911400 |           1.29 |
| Cosine Similarities | float16 | [48 2048 512]  | [48 2048 512]  | contiguous    | fwd       |  2693597 |  1422960 |           1.89 |
| Cosine Similarities | float16 | [48 2048 512]  | [48 2048 512]  | contiguous    | bwd       |  7302252 |  3825210 |           1.91 |
| Cosine Similarities | float16 | [48 2048 512]  | [48 2048 512]  | noncontiguous | fwd       | 10481655 |  8927840 |           1.17 |
| Cosine Similarities | float16 | [48 2048 512]  | [48 2048 512]  | noncontiguous | bwd       | 33497829 | 27936900 |           1.20 |
| Cosine Similarities | float16 | [8192 512 8]   | [8192 512 8]   | contiguous    | fwd       |  1855731 |   760218 |           2.44 |
| Cosine Similarities | float16 | [8192 512 8]   | [8192 512 8]   | contiguous    | bwd       |  4881614 |  3379450 |           1.44 |
| Cosine Similarities | float16 | [8192 512 8]   | [8192 512 8]   | noncontiguous | fwd       |  3529784 |   890530 |           3.96 |
| Cosine Similarities | float16 | [8192 512 8]   | [8192 512 8]   | noncontiguous | bwd       | 10447912 |  3381180 |           3.09 |
| Cosine Similarities | float16 | [8192 512 16]  | [8192 512 16]  | contiguous    | fwd       |  2646878 |  1552040 |           1.71 |
| Cosine Similarities | float16 | [8192 512 16]  | [8192 512 16]  | contiguous    | bwd       |  8911075 |  4909360 |           1.82 |

</details>

<details close>
<summary>float32</summary>
<br>

|       op_name       |  dtype  |     input1     | input2         | contiguous    | direction |   ROCm   | MIOpen   | MIOpen vs ROCm |
|:-------------------:|:-------:|:--------------:|----------------|---------------|:---------:|:--------:|----------|----------------|
| Cosine Similarities | float32 | [100 512 200]  | [100 512 200]  | contiguous    | fwd       |   577659 |   370984 |           1.56 |
| Cosine Similarities | float32 | [100 512 200]  | [100 512 200]  | contiguous    | bwd       |  1849378 |  1052470 |           1.76 |
| Cosine Similarities | float32 | [100 1024 200] | [100 1024 200] | contiguous    | fwd       |  1136999 |   746626 |           1.52 |
| Cosine Similarities | float32 | [100 1024 200] | [100 1024 200] | contiguous    | bwd       |  3618709 |  2147220 |           1.69 |
| Cosine Similarities | float32 | [100 2048 200] | [100 2048 200] | contiguous    | fwd       |  2632380 |  1524860 |           1.73 |
| Cosine Similarities | float32 | [100 2048 200] | [100 2048 200] | contiguous    | bwd       |  8504242 |  4356880 |           1.95 |
| Cosine Similarities | float32 | [48 512 512]   | [48 512 512]   | contiguous    | fwd       |   837514 |   383944 |           2.18 |
| Cosine Similarities | float32 | [48 512 512]   | [48 512 512]   | contiguous    | bwd       |  2348079 |  1042270 |           2.25 |
| Cosine Similarities | float32 | [48 512 512]   | [48 512 512]   | noncontiguous | fwd       |  3506695 |  1811310 |           1.94 |
| Cosine Similarities | float32 | [48 512 512]   | [48 512 512]   | noncontiguous | bwd       |  9166318 |  5483190 |           1.67 |
| Cosine Similarities | float32 | [48 1024 512]  | [48 1024 512]  | contiguous    | fwd       |  1160312 |   738841 |           1.57 |
| Cosine Similarities | float32 | [48 1024 512]  | [48 1024 512]  | contiguous    | bwd       |  4295953 |  2045450 |           2.10 |
| Cosine Similarities | float32 | [48 1024 512]  | [48 1024 512]  | noncontiguous | fwd       |  6700240 |  5319740 |           1.26 |
| Cosine Similarities | float32 | [48 1024 512]  | [48 1024 512]  | noncontiguous | bwd       | 19835299 | 14577400 |           1.36 |
| Cosine Similarities | float32 | [48 2048 512]  | [48 2048 512]  | contiguous    | fwd       |  2119473 |  1474480 |           1.44 |
| Cosine Similarities | float32 | [48 2048 512]  | [48 2048 512]  | contiguous    | bwd       |  8352629 |  4055320 |           2.06 |
| Cosine Similarities | float32 | [48 2048 512]  | [48 2048 512]  | noncontiguous | fwd       | 12393130 |  9287640 |           1.33 |
| Cosine Similarities | float32 | [48 2048 512]  | [48 2048 512]  | noncontiguous | bwd       | 45345268 | 31751600 |           1.43 |
| Cosine Similarities | float32 | [8192 512 8]   | [8192 512 8]   | contiguous    | fwd       |  2172193 |   903117 |           2.41 |
| Cosine Similarities | float32 | [8192 512 8]   | [8192 512 8]   | contiguous    | bwd       |  6099446 |  3222970 |           1.89 |

</details>

<details close>
<summary>bfloat16</summary>
<br>

|       op_name       |   dtype  |     input1     | input2         | contiguous    | direction |   ROCm   | MIOpen   | MIOpen vs ROCm |
|:-------------------:|:--------:|:--------------:|----------------|---------------|:---------:|:--------:|----------|----------------|
| Cosine Similarities | bfloat16 | [100 1024 200] | [100 1024 200] | contiguous    | fwd       |   846298 |   693346 |           1.22 |
| Cosine Similarities | bfloat16 | [100 1024 200] | [100 1024 200] | contiguous    | bwd       |  2977722 |  1905840 |           1.56 |
| Cosine Similarities | bfloat16 | [48 512 512]   | [48 512 512]   | contiguous    | fwd       |   520316 |   354896 |           1.47 |
| Cosine Similarities | bfloat16 | [48 512 512]   | [48 512 512]   | contiguous    | bwd       |  1880802 |  1017110 |           1.85 |
| Cosine Similarities | bfloat16 | [48 512 512]   | [48 512 512]   | noncontiguous | fwd       |  2847387 |  1336790 |           2.13 |
| Cosine Similarities | bfloat16 | [48 512 512]   | [48 512 512]   | noncontiguous | bwd       |  6875854 |  4354790 |           1.58 |
| Cosine Similarities | bfloat16 | [48 1024 512]  | [48 1024 512]  | contiguous    | fwd       |   850234 |   740263 |           1.15 |
| Cosine Similarities | bfloat16 | [48 1024 512]  | [48 1024 512]  | contiguous    | bwd       |  3515447 |  2027460 |           1.73 |
| Cosine Similarities | bfloat16 | [48 1024 512]  | [48 1024 512]  | noncontiguous | fwd       |  6123076 |  3721010 |           1.65 |
| Cosine Similarities | bfloat16 | [48 1024 512]  | [48 1024 512]  | noncontiguous | bwd       | 14947030 | 13634400 |           1.10 |
| Cosine Similarities | bfloat16 | [8192 512 8]   | [8192 512 8]   | contiguous    | fwd       |  1918707 |   745036 |           2.58 |
| Cosine Similarities | bfloat16 | [8192 512 8]   | [8192 512 8]   | contiguous    | bwd       |  5203020 |  3372960 |           1.54 |
| Cosine Similarities | bfloat16 | [8192 512 8]   | [8192 512 8]   | noncontiguous | fwd       |  3599208 |   862476 |           4.17 |
| Cosine Similarities | bfloat16 | [8192 512 8]   | [8192 512 8]   | noncontiguous | bwd       | 11091124 |  3497940 |           3.17 |
| Cosine Similarities | bfloat16 | [8192 512 16]  | [8192 512 16]  | contiguous    | fwd       |  2800925 |  1561570 |           1.79 |
| Cosine Similarities | bfloat16 | [8192 512 16]  | [8192 512 16]  | contiguous    | bwd       |  9585856 |  4725360 |           2.03 |
| Cosine Similarities | bfloat16 | [8192 512 32]  | [8192 512 32]  | contiguous    | fwd       |  4520643 |  2975230 |           1.52 |
| Cosine Similarities | bfloat16 | [8192 512 32]  | [8192 512 32]  | contiguous    | bwd       | 18413546 |  8472450 |           2.17 |
| Cosine Similarities | bfloat16 | [4096 512 8]   | [4096 512 8]   | contiguous    | fwd       |  1258264 |   469138 |           2.68 |
| Cosine Similarities | bfloat16 | [4096 512 8]   | [4096 512 8]   | contiguous    | bwd       |  3423051 |  1197620 |           2.86 |

</details>