### PR TITLE
[MV-1365] Implement SumToSize in case of inner dim reduce

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -59,6 +59,7 @@ add_executable(MIOpenDriver
     dm_rope.cpp
     dm_softmarginloss.cpp
     dm_softmax.cpp
+    dm_sumtosize.cpp
     dm_t5layernorm.cpp
     dm_tensorop.cpp
     dm_transformers_adam_w.cpp

--- a/driver/dm_sumtosize.cpp
+++ b/driver/dm_sumtosize.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "sumtosize_driver.hpp"
+#include "registry_driver_maker.hpp"
+
+static Driver* makeDriver(const std::string& base_arg)
+{
+    if(base_arg == "sumtosize")
+        return new SumToSizeDriver<float, double>();
+    if(base_arg == "sumtosizefp16")
+        return new SumToSizeDriver<float16, double>();
+    if(base_arg == "sumtosizebfp16")
+        return new SumToSizeDriver<bfloat16, double>();
+    return nullptr;
+}
+
+REGISTER_DRIVER_MAKER(makeDriver);

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -314,7 +314,7 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
            "adamw[fp16], ampadamw, transformersadamw[fp16], transformersampadamw, "
            "getitem[bfp16|fp16], reducecalculation[bfp16|fp16], rope[bfp16|fp16], "
            "prelu[bfp16|fp16], kthvalue[bfp16|fp16], glu[bfp16|fp16], softmarginloss[bfp16|fp16], "
-           "multimarginloss[bfp16|fp16]\n");
+           "multimarginloss[bfp16|fp16], sumtosize[bfp16|fp16]\n");
     exit(0); // NOLINT (concurrency-mt-unsafe)
 }
 
@@ -352,6 +352,7 @@ inline std::string ParseBaseArg(int argc, char* argv[])
        arg != "kthvaluebfp16" && arg != "glu" && arg != "glufp16" && arg != "glubfp16" &&
        arg != "softmarginloss" && arg != "softmarginlossfp16" && arg != "softmarginlossbfp16" &&
        arg != "multimarginloss" && arg != "multimarginlossfp16" && arg != "multimarginlossbfp16" &&
+       arg != "sumtosize" && arg != "sumtosizefp16" && arg != "sumtosizebfp16" &&
        arg != "--version")
     {
         printf("FAILED: Invalid Base Input Argument\n");

--- a/driver/sumtosize_driver.hpp
+++ b/driver/sumtosize_driver.hpp
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#pragma once
+
+#include "InputFlags.hpp"
+#include "driver.hpp"
+#include "miopen/miopen.h"
+#include "tensor_driver.hpp"
+#include "timer.hpp"
+#include <../test/verify.hpp>
+#include <miopen/sumtosize.hpp>
+#include <miopen/tensor_view_utils.hpp>
+
+template <typename Tgpu, typename Tcheck>
+int32_t mloSumToSizeForwardRunHost(const miopen::TensorDescriptor& inputDesc,
+                                   const miopen::TensorDescriptor& outputDesc,
+                                   const Tgpu* input,
+                                   Tcheck* output)
+{
+    std::vector<int> reduce_dims =
+        miopen::sumtosize::GetReduceDim(inputDesc.GetLengths(), outputDesc.GetLengths());
+    size_t reduce_size = 1;
+    for(auto reduce_dim : reduce_dims)
+        reduce_size *= inputDesc.GetLengths()[reduce_dim];
+    auto input_tv  = miopen::get_inner_expanded_tv<5>(inputDesc);
+    auto output_tv = miopen::get_inner_expanded_tv<5>(outputDesc);
+
+    par_ford(outputDesc.GetElementSize())([&](size_t gid) {
+        tensor_layout_t<5> idx_output(output_tv, gid);
+        for(size_t i = 0; i < reduce_size; i++)
+        {
+            // construct idx_input
+            tensor_layout_t<5> idx_input;
+            size_t reduce_idx = i;
+
+            int cur_reduce = 0;
+            for(int dim = inputDesc.GetNumDims() - 1; dim >= 0; dim--)
+            {
+                if(cur_reduce < reduce_dims.size() && dim == reduce_dims[cur_reduce])
+                {
+                    // This is reduce dim
+                    cur_reduce++;
+                    idx_input.layout[dim] = reduce_idx % input_tv.size[dim];
+                    reduce_idx /= input_tv.size[dim];
+                }
+                else
+                {
+                    // This is NOT reduce dim
+                    idx_input.layout[dim] = idx_output.layout[dim];
+                }
+            }
+            output[gid] += static_cast<Tcheck>(input[input_tv.get_tensor_view_idx(idx_input)]);
+        }
+    });
+    return miopenStatusSuccess;
+};
+
+template <typename Tgpu, typename Tref>
+class SumToSizeDriver : public Driver
+{
+public:
+    SumToSizeDriver() : Driver()
+    {
+        miopenCreateTensorDescriptor(&inputDesc);
+        miopenCreateTensorDescriptor(&outputDesc);
+
+        data_type = miopen_type<Tgpu>{};
+    }
+
+    int AddCmdLineArgs() override;
+    int ParseCmdLineArgs(int argc, char* argv[]) override;
+    InputFlags& GetInputFlags() override { return inflags; }
+
+    int GetandSetData() override;
+
+    int AllocateBuffersAndCopy() override;
+
+    int RunBackwardGPU() override;
+
+    int RunForwardGPU() override;
+    int RunForwardCPU();
+
+    Tref GetTolerance();
+    int VerifyBackward() override;
+    int VerifyForward() override;
+    ~SumToSizeDriver() override
+    {
+        miopenDestroyTensorDescriptor(inputDesc);
+        miopenDestroyTensorDescriptor(outputDesc);
+    }
+
+private:
+    InputFlags inflags;
+
+    // forw = 0 -> run both fw, bw, = 1 -> run only fw, = 2 -> run only bw
+    int forw;
+
+    miopenTensorDescriptor_t inputDesc;
+    miopenTensorDescriptor_t outputDesc;
+
+    std::unique_ptr<GPUMem> input_dev;
+    std::unique_ptr<GPUMem> output_dev;
+    std::unique_ptr<GPUMem> workspace_dev;
+
+    std::vector<Tgpu> input;
+    std::vector<Tgpu> output;
+    std::vector<Tref> ref_output;
+
+    size_t ws_sizeInBytes;
+};
+
+template <typename Tgpu, typename Tref>
+int SumToSizeDriver<Tgpu, Tref>::AddCmdLineArgs()
+{
+    inflags.AddInputFlag("forw",
+                         'F',
+                         "1",
+                         "Run Forward or Backward. 0 to run both Fw and Bw, 1 to run only Fw, 2 to "
+                         "run only Bw (Default=1)",
+                         "int");
+    inflags.AddInputFlag(
+        "input", 'I', "8x104x1", "Shape of input tensor (Default=8x104x1)", "tensor");
+    inflags.AddInputFlag(
+        "output", 'O', "1x104x1", "Shape of output tensor (Default=1x104x1)", "tensor");
+    inflags.AddInputFlag("iter", 'i', "10", "Number of Iterations (Default=10)", "int");
+    inflags.AddInputFlag("verify", 'V', "1", "Verify Each Layer (Default=1)", "int");
+    inflags.AddInputFlag("time", 't', "1", "Time Each Layer (Default=1)", "int");
+    inflags.AddInputFlag(
+        "wall", 'w', "0", "Wall-clock Time Each Layer, Requires time == 1 (Default=0)", "int");
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SumToSizeDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
+{
+    inflags.Parse(argc, argv);
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        miopenEnableProfiling(GetHandle(), true);
+    }
+    forw = inflags.GetValueInt("forw");
+    if(forw != 1)
+    {
+        MIOPEN_THROW("Only support forward mode");
+    }
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SumToSizeDriver<Tgpu, Tref>::GetandSetData()
+{
+    std::vector<int> in_len = inflags.GetValueTensor("input").lengths;
+    if(SetTensorNd(inputDesc, in_len, data_type) != miopenStatusSuccess)
+        MIOPEN_THROW("SetTensorNd: Invalid input tensor shape.");
+    std::vector<int> out_len = inflags.GetValueTensor("output").lengths;
+    if(SetTensorNd(outputDesc, out_len, data_type) != miopenStatusSuccess)
+        MIOPEN_THROW("SetTensorNd: Invalid output tensor shape.");
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SumToSizeDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
+{
+    uint32_t ctx = 0;
+
+    size_t i_sz = GetTensorSpace(inputDesc);
+    input_dev   = std::unique_ptr<GPUMem>(new GPUMem(ctx, i_sz, sizeof(Tgpu)));
+    input       = std::vector<Tgpu>(i_sz);
+
+    for(size_t i = 0; i < i_sz; i++)
+    {
+        input[i] = prng::gen_A_to_B<Tgpu>(static_cast<Tgpu>(0), static_cast<Tgpu>(1));
+    }
+    if(input_dev->ToGPU(GetStream(), input.data()) != 0)
+    {
+        std::cerr << "Error copying (input) to GPU, size: " << input_dev->GetSize() << std::endl;
+        return miopenStatusAllocFailed;
+    }
+    miopenGetSumToSizeForwardWorkSpaceSize(GetHandle(), inputDesc, outputDesc, &ws_sizeInBytes);
+    if(ws_sizeInBytes == static_cast<size_t>(-1))
+    {
+        return miopenStatusAllocFailed;
+    }
+    workspace_dev = std::make_unique<GPUMem>(ctx, ws_sizeInBytes, sizeof(std::byte));
+
+    size_t o_sz = GetTensorSpace(outputDesc);
+    output_dev  = std::unique_ptr<GPUMem>(new GPUMem(ctx, o_sz, sizeof(Tgpu)));
+    output      = std::vector<Tgpu>(o_sz);
+    ref_output  = std::vector<Tref>(o_sz);
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SumToSizeDriver<Tgpu, Tref>::RunForwardGPU()
+{
+    float kernel_total_time = 0;
+    float kernel_first_time = 0;
+
+    Timer t;
+    START_TIME
+
+    for(int i = 0; i < inflags.GetValueInt("iter"); i++)
+    {
+        miopenStatus_t status = miopenSumToSizeForward(GetHandle(),
+                                                       inputDesc,
+                                                       input_dev->GetMem(),
+                                                       outputDesc,
+                                                       output_dev->GetMem(),
+                                                       workspace_dev->GetMem(),
+                                                       ws_sizeInBytes);
+
+        MIOPEN_THROW_IF(status != miopenStatusSuccess, "Error in Forward SumToSize");
+
+        float time = 0.0;
+        miopenGetKernelTime(GetHandle(), &time);
+        kernel_total_time += time;
+        if(i == 0)
+            kernel_first_time = time;
+    }
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        STOP_TIME
+        int iter = inflags.GetValueInt("iter");
+        if(WALL_CLOCK)
+            std::cout << "Wall-clock Time Forward SumToSize Elapsed: " << t.gettime_ms() / iter
+                      << " ms" << std::endl;
+
+        float kernel_average_time =
+            iter > 1 ? (kernel_total_time - kernel_first_time) / (iter - 1) : kernel_first_time;
+        std::cout << "GPU Kernel Time Forward SumToSize Elapsed: " << kernel_average_time << " ms"
+                  << std::endl;
+    }
+
+    if(output_dev->FromGPU(GetStream(), output.data()) != 0)
+    {
+        std::cerr << "Error copying (input_grad) from GPU, size: " << output_dev->GetSize()
+                  << std::endl;
+        return miopenStatusInternalError;
+    }
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SumToSizeDriver<Tgpu, Tref>::RunBackwardGPU()
+{
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SumToSizeDriver<Tgpu, Tref>::RunForwardCPU()
+{
+    mloSumToSizeForwardRunHost(
+        miopen::deref(inputDesc), miopen::deref(outputDesc), input.data(), ref_output.data());
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+Tref SumToSizeDriver<Tgpu, Tref>::GetTolerance()
+{
+    Tref tolerance = std::numeric_limits<Tgpu>::epsilon() * 10;
+    return tolerance;
+}
+
+template <typename Tgpu, typename Tref>
+int SumToSizeDriver<Tgpu, Tref>::VerifyForward()
+{
+    RunForwardCPU();
+
+    const Tref tolerance = GetTolerance();
+    auto error           = miopen::rms_range(output, ref_output);
+    if(!std::isfinite(error) || error > tolerance)
+    {
+        std::cout << "Forward SumToSize FAILED: " << error << " > " << tolerance << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        std::cout << "Forward SumToSize Verifies OK on CPU reference (" << error << " < "
+                  << tolerance << ')' << std::endl;
+    }
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int SumToSizeDriver<Tgpu, Tref>::VerifyBackward()
+{
+    return miopenStatusSuccess;
+}

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -8176,6 +8176,51 @@ MIOPEN_EXPORT miopenStatus_t miopenMultiMarginLossForward(miopenHandle_t handle,
 // CLOSEOUT LossFunction DOXYGEN GROUP
 #endif // MIOPEN_BETA_API
 
+#ifdef MIOPEN_BETA_API
+// SumToSize APIs
+/** @addtogroup reducecalculation
+ *
+ *  @{
+ */
+
+/*! @brief Helper function to query the minimum workspace size required by the SumToSize call
+ *
+ * @param [in]   handle                   MIOpen Handle
+ * @param [in]   inputDesc                Tensor descriptor for data input tensor
+ * @param [in]   outputDesc               Tensor descriptor for output data tensor
+ * @param [out]  sizeInBytes              Pointer to data to return the minimum workspace size
+ * @return                                miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenGetSumToSizeForwardWorkSpaceSize(miopenHandle_t handle,
+                                       miopenTensorDescriptor_t inputDesc,
+                                       miopenTensorDescriptor_t outputDesc,
+                                       size_t* sizeInBytes);
+
+/*! @brief Execute a SumToSize forward layer
+ *
+ * @param [in]   handle                   MIOpen handle
+ * @param [in]   inputDesc                Tensor descriptor for data input tensor
+ * @param [in]   input                    Data input tensor
+ * @param [in]   outputDesc               Tensor descriptor for output data tensor
+ * @param [out]  output                   Data output tensor
+ * @param [in]   workspace                Address of the allocated workspace data
+ * @param [in]   workspaceSizeInBytes     Size in bytes of the allocated workspace data
+ * @param [in]   dim                      Dimension to calculation.
+ * @return                                miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t miopenSumToSizeForward(miopenHandle_t handle,
+                                                    miopenTensorDescriptor_t inputDesc,
+                                                    const void* input,
+                                                    miopenTensorDescriptor_t outputDesc,
+                                                    void* output,
+                                                    void* workspace,
+                                                    size_t workspaceSizeInBytes);
+
+/** @} */
+// CLOSEOUT REDUCE CALCULATION DOXYGEN GROUP
+#endif // MIOPEN_BETA_API
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -337,6 +337,7 @@ set( MIOpen_Source
     solver/softmax/attn_softmax.cpp
     solver/softmax/softmax.cpp
     subbuffers.cpp
+    sumtosize_api.cpp
     t5layernorm_api.cpp
     target_properties.cpp
     temp_file.cpp
@@ -703,6 +704,7 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         reduceextreme.cpp
         rope.cpp
         softmarginloss.cpp
+        sumtosize.cpp
         transformers_adam_w.cpp
         ${PROJECT_BINARY_DIR}/db_path.cpp
         )

--- a/src/include/miopen/sumtosize.hpp
+++ b/src/include/miopen/sumtosize.hpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#pragma once
+
+#include <miopen/common.hpp>
+#include <vector>
+
+namespace miopen {
+
+namespace sumtosize {
+std::vector<int> GetReduceDim(const std::vector<size_t>& inputDim,
+                              const std::vector<size_t>& outputDim);
+} // namespace sumtosize
+
+struct Handle;
+struct TensorDescriptor;
+
+MIOPEN_INTERNALS_EXPORT std::size_t GetSumToSizeForwardWorkspaceSize(
+    Handle& handle, const TensorDescriptor& inputDesc, const TensorDescriptor& outputDesc);
+
+MIOPEN_INTERNALS_EXPORT miopenStatus_t SumToSizeForward(Handle& handle,
+                                                        const TensorDescriptor& inputDesc,
+                                                        ConstData_t input,
+                                                        const TensorDescriptor& outputDesc,
+                                                        Data_t output,
+                                                        Data_t workspace,
+                                                        size_t workspaceSizeInBytes);
+
+} // namespace miopen

--- a/src/kernels/tensor_view.hpp
+++ b/src/kernels/tensor_view.hpp
@@ -83,6 +83,12 @@ struct tensor_layout_t
         }
     }
 
+    constexpr tensor_layout_t()
+    {
+        for(auto i = 0; i < N; i++)
+            layout[i] = 0;
+    }
+
     uint64_t layout[N];
 };
 

--- a/src/sumtosize.cpp
+++ b/src/sumtosize.cpp
@@ -1,0 +1,255 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "miopen/miopen.h"
+#include <miopen/datatype.hpp>
+#include <miopen/tensor.hpp>
+#include <miopen/sumtosize.hpp>
+#include <miopen/find_solution.hpp>
+#include <miopen/reduce/invoke_params.hpp>
+#include <miopen/reduce/solvers.hpp>
+#include <miopen/buffer_info.hpp>
+
+namespace miopen {
+
+namespace sumtosize {
+
+std::vector<int> GetReduceDim(const std::vector<size_t>& inputDim,
+                              const std::vector<size_t>& outputDim)
+{
+    std::vector<int> reduce_dims;
+    for(int i = inputDim.size() - 1; i >= outputDim.size(); i--)
+        if(inputDim[i] != 1)
+            reduce_dims.push_back(i);
+    for(int i = outputDim.size() - 1; i >= 0; i--)
+        if(inputDim[i] != 1 && outputDim[i] == 1)
+            reduce_dims.push_back(i);
+    if(reduce_dims.empty())
+        reduce_dims.push_back(inputDim.size() - 1);
+    return reduce_dims;
+}
+
+namespace {
+void CheckValidDim(const std::vector<size_t>& inputDim, const std::vector<size_t>& outputDim)
+{
+    if(outputDim.size() > inputDim.size())
+    {
+        MIOPEN_THROW(miopenStatusBadParm,
+                     "Output tensor num dims should not be greater than input tensor num dims.");
+    }
+    for(auto i = 0; i < outputDim.size(); i++)
+        if(outputDim[i] != inputDim[i] && outputDim[i] != 1)
+            MIOPEN_THROW(miopenStatusBadParm, "Cannot reduce input dim to output dim.");
+}
+
+MultiBufferWorkspaceTraits GetMultiBufferWorkspaceTraits(const TensorDescriptor& inputDesc,
+                                                         const std::size_t ws_size,
+                                                         const std::vector<int>& reduce_dims)
+{
+    // If reduce 1 dim, no need additional workspace
+    // If reduce 2-3 dims, need 1-2 additional workspaces
+    // If reduce > 3 dims, need 2 additional workspaces and then swap between them in each reduction
+    auto data_size = get_data_size(inputDesc.GetType());
+    if(reduce_dims.size() == 1)
+        return MultiBufferWorkspaceTraits{ws_size};
+    else if(reduce_dims.size() == 2)
+    {
+        return MultiBufferWorkspaceTraits{ws_size,
+                                          data_size * inputDesc.GetElementSize() /
+                                              inputDesc.GetLengths()[reduce_dims[0]]};
+    }
+    else
+    {
+        return MultiBufferWorkspaceTraits{
+            ws_size,
+            data_size * inputDesc.GetElementSize() / inputDesc.GetLengths()[reduce_dims[0]],
+            data_size * inputDesc.GetElementSize() / inputDesc.GetLengths()[reduce_dims[0]] /
+                inputDesc.GetLengths()[reduce_dims[1]]};
+    }
+}
+} // namespace
+
+std::size_t GetWorkspaceReductionAllDims(ExecutionContext ctx,
+                                         const TensorDescriptor& inputDesc,
+                                         const std::vector<int>& reduce_dims)
+{
+    size_t ws_size = 0;
+    std::vector<size_t> lens(inputDesc.GetLengths());
+    auto data_type = inputDesc.GetType();
+    for(int reduce_dim : reduce_dims)
+    {
+        TensorDescriptor xDesc = TensorDescriptor(data_type, lens);
+        lens[reduce_dim]       = 1;
+        // reduce::ProblemDescriptionCalculation require yDesc_ to remove reduce_dim
+        std::vector<size_t> lens_without_red(lens);
+        lens_without_red.erase(lens_without_red.begin() + reduce_dim);
+        TensorDescriptor yDesc = TensorDescriptor(data_type, lens_without_red);
+        // Tensor is always contiguous, so we don't care about stride when solving problem => don't
+        // need to pass the same lens and strides
+        const auto problem =
+            reduce::ProblemDescriptionCalculation{MIOPEN_REDUCE_CALCULATION_NOT_PROPAGATE_NAN,
+                                                  xDesc,
+                                                  yDesc,
+                                                  reduce_dim,
+                                                  MIOPEN_REDUCE_CALCULATION_SUM};
+        const auto solvers    = solver::SolverContainer<solver::reduce::SumForward>{};
+        auto pair_size_vector = solvers.GetWorkspaceSizes(ctx, problem);
+        if(pair_size_vector.empty())
+        {
+            return static_cast<size_t>(-1);
+        }
+        else
+            ws_size = std::max(ws_size, pair_size_vector.front().second);
+    }
+    return ws_size;
+}
+
+} // namespace sumtosize
+
+std::size_t GetSumToSizeForwardWorkspaceSize(Handle& handle,
+                                             const TensorDescriptor& inputDesc,
+                                             const TensorDescriptor& outputDesc)
+{
+    sumtosize::CheckValidDim(inputDesc.GetLengths(), outputDesc.GetLengths());
+    auto ctx = ExecutionContext{&handle};
+    std::vector<int> reduce_dims =
+        sumtosize::GetReduceDim(inputDesc.GetLengths(), outputDesc.GetLengths());
+
+    // we have multiple problems, each problem will reduce each dim
+    // => workspace required to solve all problems = max workspace among all problems
+    auto ws_size = sumtosize::GetWorkspaceReductionAllDims(ctx, inputDesc, reduce_dims);
+
+    // workspace required = workspace required to solve all problems + workspace to store temporary
+    // output tensor
+    return sumtosize::GetMultiBufferWorkspaceTraits(inputDesc, ws_size, reduce_dims).GetSize();
+}
+
+miopenStatus_t SumToSizeForward(Handle& handle,
+                                const TensorDescriptor& inputDesc,
+                                ConstData_t input,
+                                const TensorDescriptor& outputDesc,
+                                Data_t output,
+                                Data_t workspace,
+                                size_t /*workspaceSizeInBytes*/)
+{
+    sumtosize::CheckValidDim(inputDesc.GetLengths(), outputDesc.GetLengths());
+
+    // Get MultiBufferWorkspaceTraits. Currently we have no ways to pass MultiBufferWorkspaceTraits
+    // from GetSumToSizeForwardWorkspaceSize to SumToSizeForward so below code will be duplicate
+    // code of GetSumToSizeForwardWorkspaceSize
+    auto ctx = ExecutionContext{&handle};
+    std::vector<int> reduce_dims =
+        sumtosize::GetReduceDim(inputDesc.GetLengths(), outputDesc.GetLengths());
+    auto ws_size = sumtosize::GetWorkspaceReductionAllDims(ctx, inputDesc, reduce_dims);
+    auto wt      = sumtosize::GetMultiBufferWorkspaceTraits(inputDesc, ws_size, reduce_dims);
+
+    // Reduce each dim inside reduce_dims with solver::reduce::SumForward
+    std::vector<size_t> lens(inputDesc.GetLengths());
+    auto data_type = inputDesc.GetType();
+    Data_t reduce_in, reduce_out;
+    if(reduce_dims.size() == 2)
+    {
+        reduce_out = static_cast<Data_t>(static_cast<std::byte*>(workspace) + wt.GetOffset(1));
+    }
+    if(reduce_dims.size() >= 3)
+    {
+        reduce_out = static_cast<Data_t>(static_cast<std::byte*>(workspace) + wt.GetOffset(1));
+        reduce_in  = static_cast<Data_t>(static_cast<std::byte*>(workspace) + wt.GetOffset(2));
+    }
+
+    // Start profiling
+    // TODO: With this profiling method, start will be the start of problem, invoke_param
+    // initialization instead of first kernel call, which leads to longer time. This difference is a
+    // large number in test case with small shape
+    float elapsed = 0.0f;
+    HipEventPtr start;
+    HipEventPtr stop;
+    if(handle.IsProfilingEnabled())
+    {
+        handle.EnableProfiling(false);
+        start = miopen::make_hip_event();
+        stop  = miopen::make_hip_event();
+        hipEventRecord(start.get(), handle.GetStream());
+    }
+
+    for(int i = 0; i < reduce_dims.size(); i++)
+    {
+        TensorDescriptor xDesc = TensorDescriptor(data_type, lens);
+        lens[reduce_dims[i]]   = 1;
+        // reduce::ProblemDescriptionCalculation require yDesc_ to remove reduce_dim
+        std::vector<size_t> lens_without_red(lens);
+        lens_without_red.erase(lens_without_red.begin() + reduce_dims[i]);
+        TensorDescriptor yDesc = TensorDescriptor(data_type, lens_without_red);
+        // Tensor is always contiguous, so we don't care about stride when solving problem => don't
+        // need to pass the same lens and strides
+        const auto problem =
+            reduce::ProblemDescriptionCalculation{MIOPEN_REDUCE_CALCULATION_NOT_PROPAGATE_NAN,
+                                                  xDesc,
+                                                  yDesc,
+                                                  reduce_dims[i],
+                                                  MIOPEN_REDUCE_CALCULATION_SUM};
+
+        const auto invoke_params = [&]() {
+            auto tmp           = reduce::CalculationInvokeParams{};
+            tmp.type           = InvokeType::Run;
+            tmp.xDesc          = &xDesc;
+            tmp.yDesc          = &yDesc;
+            tmp.x              = (i == 0) ? input : reduce_in;
+            tmp.y              = (i == reduce_dims.size() - 1) ? output : reduce_out;
+            tmp.workspace      = workspace;
+            tmp.workspace_size = wt.v_offset[1];
+            tmp.nanPropagation = MIOPEN_REDUCE_CALCULATION_NOT_PROPAGATE_NAN;
+            tmp.dim            = reduce_dims[i];
+            return tmp;
+        }();
+
+        const auto algo    = AlgorithmName{"SumForward"};
+        const auto solvers = solver::SolverContainer<solver::reduce::SumForward>{};
+
+        solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
+
+        std::swap(reduce_in, reduce_out);
+    }
+
+    // End of profiling
+    if(!handle.IsProfilingEnabled())
+    {
+        hipEventRecord(stop.get(), handle.GetStream());
+        hipEventSynchronize(stop.get());
+        hipEventElapsedTime(&elapsed, start.get(), stop.get());
+
+        // Clean up
+        hipEventDestroy(start.get());
+        hipEventDestroy(stop.get());
+        handle.ResetKernelTime();
+        handle.AccumKernelTime(elapsed);
+
+        handle.EnableProfiling(true);
+    };
+    return miopenStatusSuccess;
+}
+
+} // namespace miopen

--- a/src/sumtosize.cpp
+++ b/src/sumtosize.cpp
@@ -181,9 +181,7 @@ miopenStatus_t SumToSizeForward(Handle& handle,
     }
 
     // Start profiling
-    // TODO: With this profiling method, start will be the start of problem, invoke_param
-    // initialization instead of first kernel call, which leads to longer time. This difference is a
-    // large number in test case with small shape
+    // TODO: this profiling method will count time to init problem, invoke_params, ...
     float elapsed = 0.0f;
     HipEventPtr start;
     HipEventPtr stop;

--- a/src/sumtosize_api.cpp
+++ b/src/sumtosize_api.cpp
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/sumtosize.hpp>
+#include <miopen/errors.hpp>
+#include <miopen/handle.hpp>
+#include <miopen/logger.hpp>
+#include <miopen/tensor_ops.hpp>
+
+extern "C" miopenStatus_t
+miopenGetSumToSizeForwardWorkSpaceSize(miopenHandle_t handle,
+                                       const miopenTensorDescriptor_t inputDesc,
+                                       const miopenTensorDescriptor_t outputDesc,
+                                       size_t* sizeInBytes)
+{
+    MIOPEN_LOG_FUNCTION(handle, inputDesc, outputDesc);
+
+    return miopen::try_([&] {
+        miopen::deref(sizeInBytes) = miopen::GetSumToSizeForwardWorkspaceSize(
+            miopen::deref(handle), miopen::deref(inputDesc), miopen::deref(outputDesc));
+    });
+}
+
+extern "C" miopenStatus_t miopenSumToSizeForward(miopenHandle_t handle,
+                                                 const miopenTensorDescriptor_t inputDesc,
+                                                 const void* input,
+                                                 const miopenTensorDescriptor_t outputDesc,
+                                                 void* output,
+                                                 void* workspace,
+                                                 const size_t workspaceSizeInBytes)
+{
+    MIOPEN_LOG_FUNCTION(
+        handle, inputDesc, input, outputDesc, output, workspace, workspaceSizeInBytes);
+
+    return miopen::try_([&] {
+        miopen::SumToSizeForward(miopen::deref(handle),
+                                 miopen::deref(inputDesc),
+                                 DataCast(input),
+                                 miopen::deref(outputDesc),
+                                 DataCast(output),
+                                 DataCast(workspace),
+                                 workspaceSizeInBytes);
+    });
+}

--- a/test/cpu_sumtosize.hpp
+++ b/test/cpu_sumtosize.hpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include "tensor_holder.hpp"
+#include <miopen/sumtosize.hpp>
+#include <miopen/tensor_view_utils.hpp>
+
+template <class T>
+void cpu_sumtosize_forward(const tensor<T> input, tensor<T>& output)
+{
+    std::vector<int> reduce_dims =
+        miopen::sumtosize::GetReduceDim(input.desc.GetLengths(), output.desc.GetLengths());
+    size_t reduce_size = 1;
+    for(auto reduce_dim : reduce_dims)
+        reduce_size *= input.desc.GetLengths()[reduce_dim];
+    auto input_tv  = miopen::get_inner_expanded_tv<5>(input.desc);
+    auto output_tv = miopen::get_inner_expanded_tv<5>(output.desc);
+
+    par_ford(output.desc.GetElementSize())([&](size_t gid) {
+        tensor_layout_t<5> idx_output(output_tv, gid);
+        double res = 0;
+        for(size_t i = 0; i < reduce_size; i++)
+        {
+            // construct idx_input
+            tensor_layout_t<5> idx_input;
+            size_t reduce_idx = i;
+
+            int cur_reduce = 0;
+
+            for(int dim = input.desc.GetNumDims() - 1; dim >= 0; dim--)
+            {
+                if(cur_reduce < reduce_dims.size() && dim == reduce_dims[cur_reduce])
+                {
+                    // This is reduce dim
+                    cur_reduce++;
+                    idx_input.layout[dim] = reduce_idx % input_tv.size[dim];
+                    reduce_idx /= input_tv.size[dim];
+                }
+                else
+                {
+                    // This is NOT reduce dim
+                    idx_input.layout[dim] = idx_output.layout[dim];
+                }
+            }
+
+            res += static_cast<double>(input[input_tv.get_tensor_view_idx(idx_input)]);
+        }
+        output[gid] = static_cast<T>(res);
+    });
+}

--- a/test/gtest/sumtosize.cpp
+++ b/test/gtest/sumtosize.cpp
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "sumtosize.hpp"
+
+namespace sumtosize {
+
+struct GPU_SumToSizeForward_FP32 : SumToSizeForwardTest<float>
+{
+};
+
+struct GPU_SumToSizeForward_FP16 : SumToSizeForwardTest<half_float::half>
+{
+};
+
+struct GPU_SumToSizeForward_BFP16 : SumToSizeForwardTest<bfloat16>
+{
+};
+
+} // namespace sumtosize
+
+using sumtosize::GPU_SumToSizeForward_BFP16;
+using sumtosize::GPU_SumToSizeForward_FP16;
+using sumtosize::GPU_SumToSizeForward_FP32;
+
+TEST_P(GPU_SumToSizeForward_FP32, Test)
+{
+    RunTest();
+    Verify();
+};
+
+TEST_P(GPU_SumToSizeForward_FP16, Test)
+{
+    RunTest();
+    Verify();
+};
+
+TEST_P(GPU_SumToSizeForward_BFP16, Test)
+{
+    RunTest();
+    Verify();
+};
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_SumToSizeForward_FP32,
+                         testing::ValuesIn(SumToSizeTestConfigs()));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_SumToSizeForward_FP16,
+                         testing::ValuesIn(SumToSizeTestConfigs()));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_SumToSizeForward_BFP16,
+                         testing::ValuesIn(SumToSizeTestConfigs()));

--- a/test/gtest/sumtosize.hpp
+++ b/test/gtest/sumtosize.hpp
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "cpu_sumtosize.hpp"
+#include "get_handle.hpp"
+#include "tensor_holder.hpp"
+#include "verify.hpp"
+#include <gtest/gtest.h>
+#include <miopen/sumtosize.hpp>
+
+struct SumToSizeTestCase
+{
+    std::vector<size_t> input_dims;
+    std::vector<size_t> output_dims;
+
+    friend std::ostream& operator<<(std::ostream& os, const SumToSizeTestCase& tc)
+    {
+        os << "input_dims:";
+        os << tc.input_dims[0];
+        for(int i = 1; i < tc.input_dims.size(); i++)
+            os << "x" << tc.input_dims[i];
+        os << ", output_dims:" << tc.output_dims[0];
+        for(int i = 1; i < tc.output_dims.size(); i++)
+            os << "x" << tc.output_dims[i];
+        return os;
+    }
+};
+
+inline std::vector<SumToSizeTestCase> SumToSizeTestConfigs()
+{
+    // clang-format off
+    return {
+        {{8, 120, 1}, {1, 120, 1}}, 
+        {{8, 120, 50265}, {1, 120, 50265}},
+        {{8, 1023, 1}, {1, 1023, 1}},
+        {{8, 1023, 50257}, {1, 1023, 50257}},
+        {{16384, 768}, {1, 768}},
+        {{8192, 3072}, {1, 3072}},
+        {{8192, 2304}, {1, 2304}},
+        {{16, 512, 1024}, {1, 512, 1024}},
+        {{48, 8, 512, 512}, {1, 8, 512, 512}},
+        {{40, 512, 768}, {1, 512, 768}},
+        {{256, 4, 8732}, {256, 1, 8732}},
+        {{841, 64, 2, 1024}, {841, 64, 1, 1024}},
+        {{16, 311, 99, 512}, {16, 311, 1, 512}},
+        {{1, 128, 512}, {1, 1, 512}},
+        {{64, 8, 128, 128}, {1, 8, 128, 128}},
+        {{64, 128, 768}, {1, 128, 768}},
+        {{48, 512, 512}, {1, 1, 512}},
+        {{16, 16, 16, 16, 16}, {1, 1, 1, 1, 16}}
+    };
+    // clang-format on
+}
+
+template <typename T = float>
+struct SumToSizeForwardTest : public ::testing::TestWithParam<SumToSizeTestCase>
+{
+protected:
+    void SetUp() override
+    {
+        auto&& handle = get_handle();
+        config        = GetParam();
+
+        input             = tensor<T>{config.input_dims};
+        auto gen_in_value = [](auto...) {
+            return prng::gen_A_to_B<T>(static_cast<T>(0), static_cast<T>(1));
+        };
+        std::generate(input.begin(), input.end(), gen_in_value);
+        input_dev = handle.Write(input.data);
+
+        output     = tensor<T>{config.output_dims};
+        output_dev = handle.Create<T>(output.GetSize());
+        ref_output = tensor<T>{config.output_dims};
+
+        ws_sizeInBytes = miopen::GetSumToSizeForwardWorkspaceSize(handle, input.desc, output.desc);
+        if(ws_sizeInBytes == static_cast<size_t>(-1))
+            GTEST_FAIL() << "Call GetSumToSizeForwardWorkspaceSize failed!";
+        if(ws_sizeInBytes > 0)
+        {
+            workspace_dev = handle.Create<std::byte>(ws_sizeInBytes);
+        }
+        else
+        {
+            workspace_dev = nullptr;
+        }
+    }
+
+    void RunTest()
+    {
+        auto&& handle = get_handle();
+
+        cpu_sumtosize_forward<T>(input, ref_output);
+
+        miopenStatus_t status;
+        status = miopen::SumToSizeForward(handle,
+                                          input.desc,
+                                          input_dev.get(),
+                                          output.desc,
+                                          output_dev.get(),
+                                          workspace_dev.get(),
+                                          ws_sizeInBytes);
+
+        ASSERT_EQ(status, miopenStatusSuccess);
+
+        // Write from GPU to CPU
+        output.data = handle.Read<T>(output_dev, output.data.size());
+    }
+
+    void Verify()
+    {
+        auto tolerance = std::numeric_limits<T>::epsilon() * 10;
+
+        auto error = miopen::rms_range(ref_output, output);
+        ASSERT_EQ(miopen::range_distance(ref_output), miopen::range_distance(output));
+        EXPECT_LT(error, tolerance);
+    }
+    SumToSizeTestCase config;
+
+    tensor<T> input;
+    tensor<T> output;
+
+    tensor<T> ref_output;
+
+    miopen::Allocator::ManageDataPtr input_dev;
+    miopen::Allocator::ManageDataPtr output_dev;
+    miopen::Allocator::ManageDataPtr workspace_dev;
+
+    size_t ws_sizeInBytes;
+};


### PR DESCRIPTION
- This PR implement [torch.Tensor.sum_to_size](https://pytorch.org/docs/stable/generated/torch.Tensor.sum_to_size.html#torch.Tensor.sum_to_size). **The API will call multiple solvers from https://github.com/ROCm/MIOpen/pull/2543 instead of implementing new solver and kernel because they have the same logic and modnn also did the same thing.** Because of that, this PR will be different from other PRs. The main logic is inside `src/sumtosize.cpp`
- There are some problems that need more time to address, though:
  - Because the API will call multiple solvers to solve the problem, the benchmark method I used in this PR will start and end the benchmark at the beginning and the end of SumForward, so the time to initialize other things like ProblemDescription, InvokeParams, ... will also be counted. In test cases with big shape it is not a problem but in test cases with small shape we can easily see the difference. The benchmark result should only equal `end time of last kernel - start time of first kernel`. To implement correct benchmark result we need to implement everything in only one new solver and call every kernel inside it, but that will generate many duplicate code similar to https://github.com/ROCm/MIOpen/pull/2543 [?] 
  - The benchmark result will be the same as https://github.com/ROCm/MIOpen/pull/2543. However, MIOpen benchmark result from that PR is wrong in half of the test cases. The real result I got will lead to MIOpen slower than ROCm, but in that PR's result is faster. However, modnn benchmark result in those wrong test cases is faster, so I think there may be something wrong with SumForward implementation. (need more time to investigate)